### PR TITLE
Modified devectorize_axes in plotting/tools.py

### DIFF
--- a/astroML/plotting/tools.py
+++ b/astroML/plotting/tools.py
@@ -35,7 +35,7 @@ def devectorize_axes(ax=None, dpi=None, transparent=True):
     _sp = {}
     for k in ax.spines:
         _sp[k] = ax.spines[k].get_visible()
-	    ax.spines[k].set_visible(False)
+        ax.spines[k].set_visible(False)
     _xax = ax.xaxis.get_visible()
     _yax = ax.yaxis.get_visible()
     _patch = ax.axesPatch.get_visible()


### PR DESCRIPTION
I changed the call keywords and some internal tricks

Default ax is gca()
Temporary image name can be changed (using python tempfile would be better)
Axes, Axes' Patch, BBox are hidden for the image.
transparent background is used during the png export (keyword added to the call)
