### PR TITLE
Fix the missing log term in ncp_prior

### DIFF
--- a/astroML/density_estimation/bayesian_blocks.py
+++ b/astroML/density_estimation/bayesian_blocks.py
@@ -80,7 +80,7 @@ class Events(FitnessFunc):
             return self.gamma_prior(N, Ntot)
         else:
             # eq. 21 from Scargle 2012
-            return 4 - 73.53 * self.p0 * (N ** -0.478)
+            return 4 - np.log(73.53 * self.p0 * (N ** -0.478))
 
 
 class RegularEvents(FitnessFunc):


### PR DESCRIPTION
In the ApJ paper (Scargle 2013, 764:167), equation 21 is missing a log term. Please see http://arxiv.org/pdf/1304.281 for the correction.
