### PR TITLE
DEPENDENCY: change pyfits to astropy.io

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
-0.1
+0.2
 ===
-*Initial release, October 2012*
+- Documentation and example updates
+- Moved from using ``pyfits`` to using ``astropy.io.fits``
+- Fix the prior for the Bayesian Blocks algorithm
 
 0.1.1
 =====
@@ -11,3 +13,7 @@
 - Performance improvement in ``freedman_bin_width``
 - Fix setup issue when sklearn is not installed
 - Enhancements to ``devectorize_axes`` function
+
+0.1
+===
+*Initial release, October 2012*

--- a/README.rst
+++ b/README.rst
@@ -101,11 +101,10 @@ The core ``astroML`` package requires the following:
 - Scipy_ >= 0.7
 - Scikit-learn_ >= 0.10
 - Matplotlib_ >= 0.99
-- PyFITS_ >= 3.0.
-  PyFITS is a python reader for Flexible Image Transport
-  System (FITS) files, based on cfitsio.  Several of the dataset loaders
-  require pyfits.
-
+- AstroPy_ > 0.2.5
+  AstroPy is required to read Flexible Image Transport
+  System (FITS) files, which are used by several datasets.
+  
 This configuration matches the Ubuntu 10.04 LTS release from April 2010,
 with the addition of scikit-learn.
 
@@ -221,7 +220,7 @@ Code Contribution
 .. _Scipy: http://www.scipy.org
 .. _Scikit-learn: http://scikit-learn.org
 .. _Matplotlib: http://matplotlib.org
-.. _PyFITS: http://www.stsci.edu/institute/software_hardware/pyfits
+.. _AstroPy: http://www.astropy.org/
 .. _PyMC: http://pymc-devs.github.com/pymc/
 .. _HEALPy: https://github.com/healpy/healpy>
 .. _Git: http://git-scm.com/

--- a/astroML/datasets/imaging_sample.py
+++ b/astroML/datasets/imaging_sample.py
@@ -90,8 +90,8 @@ def fetch_imaging_sample(data_home=None, download_if_missing=True):
           p.modelMag_r < 22.5
         --- the end of query
     """
-    # pyfits is an optional dependency: don't import globally
-    import pyfits
+    # fits is an optional dependency: don't import globally
+    from astropy.io import fits
 
     data_home = get_data_home(data_home)
     if not os.path.exists(data_home):
@@ -107,5 +107,5 @@ def fetch_imaging_sample(data_home=None, download_if_missing=True):
         fitsdata = download_with_progress_bar(DATA_URL)
         open(archive_file, 'wb').write(fitsdata)
 
-    hdulist = pyfits.open(archive_file)
+    hdulist = fits.open(archive_file)
     return np.asarray(hdulist[1].data)

--- a/astroML/datasets/rrlyrae_mags.py
+++ b/astroML/datasets/rrlyrae_mags.py
@@ -45,8 +45,8 @@ def fetch_rrlyrae_mags(data_home=None, download_if_missing=True):
     -----
     This data is from table 1 of Sesar et al 2010 ApJ 708:717
     """
-    # pyfits is an optional dependency: don't import globally
-    import pyfits
+    # fits is an optional dependency: don't import globally
+    from astropy.io import fits
 
     data_home = get_data_home(data_home)
     if not os.path.exists(data_home):
@@ -62,7 +62,7 @@ def fetch_rrlyrae_mags(data_home=None, download_if_missing=True):
         fitsdata = download_with_progress_bar(DATA_URL)
         open(archive_file, 'wb').write(fitsdata)
 
-    hdulist = pyfits.open(archive_file)
+    hdulist = fits.open(archive_file)
     return np.asarray(hdulist[1].data)
 
 

--- a/astroML/datasets/sdss_specgals.py
+++ b/astroML/datasets/sdss_specgals.py
@@ -81,8 +81,8 @@ def fetch_sdss_specgals(data_home=None, download_if_missing=True):
     >>> print data['dec'][:3]  #  first three declination values
     [-1.04127639 -0.6522198  -0.7651468 ]
     """
-    # pyfits is an optional dependency: don't import globally
-    import pyfits
+    # fits is an optional dependency: don't import globally
+    from astropy.io import fits
 
     data_home = get_data_home(data_home)
     if not os.path.exists(data_home):
@@ -98,7 +98,7 @@ def fetch_sdss_specgals(data_home=None, download_if_missing=True):
         fitsdata = download_with_progress_bar(DATA_URL)
         open(archive_file, 'wb').write(fitsdata)
 
-    hdulist = pyfits.open(archive_file)
+    hdulist = fits.open(archive_file)
     return np.asarray(hdulist[1].data)
 
 

--- a/astroML/datasets/sdss_sspp.py
+++ b/astroML/datasets/sdss_sspp.py
@@ -104,8 +104,8 @@ def fetch_sdss_sspp(data_home=None, download_if_missing=True, cleaned=False):
     >>> print data['dec'][:2]  # first two DEC values
     [-1.04175591 -0.64250112]
     """
-    # pyfits is an optional dependency: don't import globally
-    import pyfits
+    # fits is an optional dependency: don't import globally
+    from astropy.io import fits
 
     data_home = get_data_home(data_home)
     if not os.path.exists(data_home):
@@ -121,7 +121,7 @@ def fetch_sdss_sspp(data_home=None, download_if_missing=True, cleaned=False):
         fitsdata = download_with_progress_bar(DATA_URL)
         open(archive_file, 'wb').write(fitsdata)
 
-    hdulist = pyfits.open(archive_file)
+    hdulist = fits.open(archive_file)
 
     data = np.asarray(hdulist[1].data)
 

--- a/astroML/datasets/tools/sdss_fits.py
+++ b/astroML/datasets/tools/sdss_fits.py
@@ -61,7 +61,7 @@ class SDSSfits(object):
     -----
     This class only provides access to a subset of the information available
     in the sdss spectra fits file.  The raw fits data can be accessed using
-    the pyfits object directly.  This can be found in the attribute
+    the fits object directly.  This can be found in the attribute
     ``hdulist``.  For details, please refer to the data description:
     http://www.sdss.org/dr7/dm/flatFiles/spSpec.html
     """
@@ -77,15 +77,15 @@ class SDSSfits(object):
             self._load_fits_file(source)
 
     def _load_fits_url(self, url):
-        # pyfits is an optional dependency: don't import globally
-        import pyfits
+        # fits is an optional dependency: don't import globally
+        from astropy.io import fits
         buffer = download_with_progress_bar(url, return_buffer=True)
-        self._initialize(pyfits.open(buffer))
+        self._initialize(fits.open(buffer))
 
     def _load_fits_file(self, file_or_buffer):
-        # pyfits is an optional dependency: don't import globally
-        import pyfits
-        self._initialize(pyfits.open(file_or_buffer))
+        # fits is an optional dependency: don't import globally
+        from astropy.io import fits
+        self._initialize(fits.open(file_or_buffer))
 
     def _initialize(self, hdulist):
         data = hdulist[0].data

--- a/doc/user_guide/installation.rst
+++ b/doc/user_guide/installation.rst
@@ -114,10 +114,9 @@ The core ``astroML`` package requires the following:
 - `Scipy <http://www.scipy.org/>`_ >= 0.7
 - `scikit-learn <http://scikit-learn.org/>`_ >= 0.10
 - `matplotlib <http://matplotlib.org/>`_ >= 0.99
-- `pyfits <http://www.stsci.edu/institute/software_hardware/pyfits>`_ >= 3.0.
-  PyFITS is a python reader for Flexible Image Transport
-  System (FITS) files, based on cfitsio.  Several of the dataset loaders
-  require pyfits.
+- `astropy <http://www.astropy.org/>`_ >= 0.2.5
+  AstroPy is required to read Flexible Image Transport
+  System (FITS) files, which are used by several datasets.
 
 This configuration matches the Ubuntu 10.04 LTS release from April 2010,
 with the addition of scikit-learn.


### PR DESCRIPTION
This PR changes the deprecated `pyfits` dependency in favor of `astropy.io.fits`.
