### PR TITLE
Fix failure to import itertool.product in combinations_with_replacement

### DIFF
--- a/astroML/utils.py
+++ b/astroML/utils.py
@@ -12,9 +12,10 @@ except:
         allowing individual elements to have successive repeats.
         combinations_with_replacement('ABC', 2) --> AA AB AC BB BC CC
         """
+        from itertools import product
         pool = tuple(iterable)
         n = len(pool)
-        for indices in itertools.product(range(n), repeat=r):
+        for indices in product(range(n), repeat=r):
             if sorted(indices) == list(indices):
                 yield tuple(pool[i] for i in indices)
 


### PR DESCRIPTION
combinations_with_replacements doesn't work in python 2.6 because itertools.product was not imported.
