### PR TITLE
Use astropy.cosmology instead of built-in cosmology when possible.

### DIFF
--- a/astroML/cosmology.py
+++ b/astroML/cosmology.py
@@ -3,6 +3,8 @@ from scipy import integrate
 import pylab as pl
 
 
+import warnings
+
 class Cosmology(object):
     """Class to enable simple cosmological calculations.
 
@@ -22,6 +24,7 @@ class Cosmology(object):
     [1] http://roban.github.com/CosmoloPy/
     """
     def __init__(self, omegaM=0.27, omegaL=0.73, h=0.71):
+        warnings.warn("deprecated", DeprecationWarning)
         self.omegaM = omegaM
         self.omegaL = omegaL
         self.omegaK = 1. - omegaM - omegaL

--- a/astroML/cosmology.py
+++ b/astroML/cosmology.py
@@ -5,6 +5,7 @@ import pylab as pl
 
 import warnings
 
+
 class Cosmology(object):
     """Class to enable simple cosmological calculations.
 
@@ -24,7 +25,7 @@ class Cosmology(object):
     [1] http://roban.github.com/CosmoloPy/
     """
     def __init__(self, omegaM=0.27, omegaL=0.73, h=0.71):
-        warnings.warn("deprecated", DeprecationWarning)
+        warnings.warn("deprecated; use astropy.cosmology", DeprecationWarning)
         self.omegaM = omegaM
         self.omegaL = omegaL
         self.omegaK = 1. - omegaM - omegaL

--- a/astroML/datasets/generated.py
+++ b/astroML/datasets/generated.py
@@ -1,15 +1,13 @@
 import numpy as np
-from ..cosmology import Cosmology
 from ..density_estimation import FunctionDistribution
 from ..utils import check_random_state
-
 
 def redshift_distribution(z, z0):
     return (z / z0) ** 2 * np.exp(-1.5 * (z / z0))
 
 
 def generate_mu_z(size=1000, z0=0.3, dmu_0=0.1, dmu_1=0.02,
-                  random_state=None, **kwargs):
+                  random_state=None):
     """Generate a dataset of distance modulus vs redshift.
 
     Parameters
@@ -23,23 +21,37 @@ def generate_mu_z(size=1000, z0=0.3, dmu_0=0.1, dmu_1=0.02,
         specify the error in mu, dmu = dmu_0 + dmu_1 * mu
     random_state : None, int, or np.random.RandomState instance
         random seed or random number generator
-    **kwargs :
-        additional keyword arguments are passed to the Cosmology function
 
     Returns
     -------
     z, mu, dmu : ndarrays
         arrays of shape `size`
     """
-    random_state = check_random_state(random_state)
-    cosmo = Cosmology(**kwargs)
+    
+    try:
+        from astropy.cosmology import FlatLambdaCDM
+        ver = astropy.__version__.split('.')
+        if int(ver[0]) == 0 and int(ver[1]) < 3:
+            raise ImportError("Insufficient astropy version; using builtin")
+        # Use same params as default Cosmology object
+        cosmo = FlatLambdaCDM(71, 0.27, Tcmb0=0)
+    except ImportError:
+        from ..cosmology import Cosmology
+        cosmo = Cosmology()
 
+    random_state = check_random_state(random_state)
     zdist = FunctionDistribution(redshift_distribution, func_args=dict(z0=z0),
                                  xmin=0.1 * z0, xmax=10 * z0,
                                  random_state=random_state)
 
     z_sample = zdist.rvs(size)
-    mu_sample = np.asarray(map(cosmo.mu, np.ravel(z_sample))).reshape(size)
+    try:
+        # Astropy
+        mu_sample = cosmo.distmod(np.ravel(z_sample)).value.reshape(size)
+    except AttributeError:
+        # Built in
+        mu_sample = np.asarray(map(cosmo.mu, np.ravel(z_sample))).reshape(size)
+
     dmu = dmu_0 + dmu_1 * mu_sample
     mu_sample = random_state.normal(mu_sample, dmu)
 

--- a/astroML/datasets/generated.py
+++ b/astroML/datasets/generated.py
@@ -2,42 +2,43 @@ import numpy as np
 from ..density_estimation import FunctionDistribution
 from ..utils import check_random_state
 
+
 def redshift_distribution(z, z0):
     return (z / z0) ** 2 * np.exp(-1.5 * (z / z0))
 
 
 def generate_mu_z(size=1000, z0=0.3, dmu_0=0.1, dmu_1=0.02,
-                  random_state=None):
+                  random_state=None, cosmo=None):
     """Generate a dataset of distance modulus vs redshift.
 
     Parameters
     ----------
     size : int or tuple
         size of generated data
+
     z0 : float
         parameter in redshift distribution:
         p(z) ~ (z / z0)^2 exp[-1.5 (z / z0)]
+
     dmu_0, dmu_1 : float
         specify the error in mu, dmu = dmu_0 + dmu_1 * mu
+
     random_state : None, int, or np.random.RandomState instance
         random seed or random number generator
+
+    cosmo : astropy.cosmology instance specifying cosmology
+        to use when generating the sample.  If not provided,
+        a Flat Lambda CDM model with h=0.71, Omega_m=0.27 is used.
 
     Returns
     -------
     z, mu, dmu : ndarrays
         arrays of shape `size`
     """
-    
-    try:
-        from astropy.cosmology import FlatLambdaCDM
-        ver = astropy.__version__.split('.')
-        if int(ver[0]) == 0 and int(ver[1]) < 3:
-            raise ImportError("Insufficient astropy version; using builtin")
-        # Use same params as default Cosmology object
-        cosmo = FlatLambdaCDM(71, 0.27, Tcmb0=0)
-    except ImportError:
-        from ..cosmology import Cosmology
-        cosmo = Cosmology()
+
+    if cosmo is None:
+        import astropy.cosmology
+        cosmo = astropy.cosmology.FlatLambdaCDM(71, 0.27, Tcmb0=0)
 
     random_state = check_random_state(random_state)
     zdist = FunctionDistribution(redshift_distribution, func_args=dict(z0=z0),
@@ -45,12 +46,7 @@ def generate_mu_z(size=1000, z0=0.3, dmu_0=0.1, dmu_1=0.02,
                                  random_state=random_state)
 
     z_sample = zdist.rvs(size)
-    try:
-        # Astropy
-        mu_sample = cosmo.distmod(np.ravel(z_sample)).value.reshape(size)
-    except AttributeError:
-        # Built in
-        mu_sample = np.asarray(map(cosmo.mu, np.ravel(z_sample))).reshape(size)
+    mu_sample = cosmo.distmod(np.ravel(z_sample)).value.reshape(size)
 
     dmu = dmu_0 + dmu_1 * mu_sample
     mu_sample = random_state.normal(mu_sample, dmu)

--- a/astroML/datasets/sdss_specgals.py
+++ b/astroML/datasets/sdss_specgals.py
@@ -103,133 +103,6 @@ def fetch_sdss_specgals(data_home=None, download_if_missing=True):
 
 
 def fetch_great_wall(data_home=None, download_if_missing=True,
-                     xlim=(-375, -175), ylim=(-300, 200)):
-    """Get the 2D SDSS "Great Wall" distribution, following Cowan et al 2008
-
-    Parameters
-    ----------
-    data_home : optional, default=None
-        Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
-
-    download_if_missing : optional, default=True
-        If False, raise a IOError if the data is not locally available
-        instead of trying to download the data from the source site.
-
-    xlim, ylim : tuples or None
-        the limits in Mpc of the data: default values are the same as that
-        used for the plots in Cowan 2008.  If set to None, no cuts will
-        be performed.
-
-    Returns
-    -------
-    data : ndarray, shape = (Ngals, 2)
-        grid of projected (x, y) locations of galaxies in Mpc
-    """
-    # local imports so we don't need dependencies for loading module
-    from scipy.interpolate import interp1d
-
-    import get_data_home
-    from tools import download_with_progress_bar
-
-DATA_URL = ("http://www.astro.washington.edu/users/ivezic/"
-            "DMbook/data/SDSSspecgalsDR8.fit")
-
-
-def fetch_sdss_specgals(data_home=None, download_if_missing=True):
-    """Loader for SDSS Galaxies with spectral information
-
-    Parameters
-    ----------
-    data_home : optional, default=None
-        Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
-
-    download_if_missing : optional, default=True
-        If False, raise a IOError if the data is not locally available
-        instead of trying to download the data from the source site.
-
-    Returns
-    -------
-    data : recarray, shape = (327260,)
-        record array containing pipeline parameters
-
-    Notes
-    -----
-    These were compiled from the SDSS database using the following SQL query::
-
-        SELECT
-          G.ra, G.dec, S.mjd, S.plate, S.fiberID, --- basic identifiers
-          --- basic spectral data
-          S.z, S.zErr, S.rChi2, S.velDisp, S.velDispErr,
-          --- some useful imaging parameters
-          G.extinction_r, G.petroMag_r, G.psfMag_r, G.psfMagErr_r,
-          G.modelMag_u, modelMagErr_u, G.modelMag_g, modelMagErr_g,
-          G.modelMag_r, modelMagErr_r, G.modelMag_i, modelMagErr_i,
-          G.modelMag_z, modelMagErr_z, G.petroR50_r, G.petroR90_r,
-          --- line fluxes for BPT diagram and other derived spec. parameters
-          GSL.nii_6584_flux, GSL.nii_6584_flux_err, GSL.h_alpha_flux,
-          GSL.h_alpha_flux_err, GSL.oiii_5007_flux, GSL.oiii_5007_flux_err,
-          GSL.h_beta_flux, GSL.h_beta_flux_err, GSL.h_delta_flux,
-          GSL.h_delta_flux_err, GSX.d4000, GSX.d4000_err, GSE.bptclass,
-          GSE.lgm_tot_p50, GSE.sfr_tot_p50, G.objID, GSI.specObjID
-        INTO mydb.SDSSspecgalsDR8 FROM SpecObj S CROSS APPLY
-          dbo.fGetNearestObjEQ(S.ra, S.dec, 0.06) N, Galaxy G,
-          GalSpecInfo GSI, GalSpecLine GSL, GalSpecIndx GSX, GalSpecExtra GSE
-        WHERE N.objID = G.objID
-          AND GSI.specObjID = S.specObjID
-          AND GSL.specObjID = S.specObjID
-          AND GSX.specObjID = S.specObjID
-          AND GSE.specObjID = S.specObjID
-          --- add some quality cuts to get rid of obviously bad measurements
-          AND (G.petroMag_r > 10 AND G.petroMag_r < 18)
-          AND (G.modelMag_u-G.modelMag_r) > 0
-          AND (G.modelMag_u-G.modelMag_r) < 6
-          AND (modelMag_u > 10 AND modelMag_u < 25)
-          AND (modelMag_g > 10 AND modelMag_g < 25)
-          AND (modelMag_r > 10 AND modelMag_r < 25)
-          AND (modelMag_i > 10 AND modelMag_i < 25)
-          AND (modelMag_z > 10 AND modelMag_z < 25)
-          AND S.rChi2 < 2
-          AND (S.zErr > 0 AND S.zErr < 0.01)
-          AND S.z > 0.02
-          --- end of query ---
-
-    Examples
-    --------
-    >>> from astroML.datasets import fetch_sdss_specgals
-    >>> data = fetch_sdss_specgals()
-    >>> data.shape  # number of objects in dataset
-    (661598,)
-    >>> data.names[:5]  # first five column names
-    ['ra', 'dec', 'mjd', 'plate', 'fiberID']
-    >>> print data['ra'][:3]  # first three RA values
-    [ 146.71419105  146.74414186  146.62857334]
-    >>> print data['dec'][:3]  #  first three declination values
-    [-1.04127639 -0.6522198  -0.7651468 ]
-    """
-    # fits is an optional dependency: don't import globally
-    from astropy.io import fits
-
-    data_home = get_data_home(data_home)
-    if not os.path.exists(data_home):
-        os.makedirs(data_home)
-
-    archive_file = os.path.join(data_home, os.path.basename(DATA_URL))
-
-    if not os.path.exists(archive_file):
-        if not download_if_missing:
-            raise IOError('data not present on disk. '
-                          'set download_if_missing=True to download')
-
-        fitsdata = download_with_progress_bar(DATA_URL)
-        open(archive_file, 'wb').write(fitsdata)
-
-    hdulist = fits.open(archive_file)
-    return np.asarray(hdulist[1].data)
-
-
-def fetch_great_wall(data_home=None, download_if_missing=True,
                      xlim=(-375, -175), ylim=(-300, 200), cosmo=None):
     """Get the 2D SDSS "Great Wall" distribution, following Cowan et al 2008
 
@@ -278,7 +151,7 @@ def fetch_great_wall(data_home=None, download_if_missing=True,
 
     # first sample the distance modulus on a grid
     zgrid = np.linspace(min(data['z']), max(data['z']), 100)
-    mugrid = cosmo.distmod(z).value
+    mugrid = cosmo.distmod(zgrid).value
     f = interp1d(zgrid, mugrid)
     mu = f(data['z'])
 

--- a/astroML/datasets/sdss_specgals.py
+++ b/astroML/datasets/sdss_specgals.py
@@ -128,7 +128,148 @@ def fetch_great_wall(data_home=None, download_if_missing=True,
     """
     # local imports so we don't need dependencies for loading module
     from scipy.interpolate import interp1d
-    from ..cosmology import Cosmology
+
+    import get_data_home
+    from tools import download_with_progress_bar
+
+DATA_URL = ("http://www.astro.washington.edu/users/ivezic/"
+            "DMbook/data/SDSSspecgalsDR8.fit")
+
+
+def fetch_sdss_specgals(data_home=None, download_if_missing=True):
+    """Loader for SDSS Galaxies with spectral information
+
+    Parameters
+    ----------
+    data_home : optional, default=None
+        Specify another download and cache folder for the datasets. By default
+        all scikit learn data is stored in '~/astroML_data' subfolders.
+
+    download_if_missing : optional, default=True
+        If False, raise a IOError if the data is not locally available
+        instead of trying to download the data from the source site.
+
+    Returns
+    -------
+    data : recarray, shape = (327260,)
+        record array containing pipeline parameters
+
+    Notes
+    -----
+    These were compiled from the SDSS database using the following SQL query::
+
+        SELECT
+          G.ra, G.dec, S.mjd, S.plate, S.fiberID, --- basic identifiers
+          --- basic spectral data
+          S.z, S.zErr, S.rChi2, S.velDisp, S.velDispErr,
+          --- some useful imaging parameters
+          G.extinction_r, G.petroMag_r, G.psfMag_r, G.psfMagErr_r,
+          G.modelMag_u, modelMagErr_u, G.modelMag_g, modelMagErr_g,
+          G.modelMag_r, modelMagErr_r, G.modelMag_i, modelMagErr_i,
+          G.modelMag_z, modelMagErr_z, G.petroR50_r, G.petroR90_r,
+          --- line fluxes for BPT diagram and other derived spec. parameters
+          GSL.nii_6584_flux, GSL.nii_6584_flux_err, GSL.h_alpha_flux,
+          GSL.h_alpha_flux_err, GSL.oiii_5007_flux, GSL.oiii_5007_flux_err,
+          GSL.h_beta_flux, GSL.h_beta_flux_err, GSL.h_delta_flux,
+          GSL.h_delta_flux_err, GSX.d4000, GSX.d4000_err, GSE.bptclass,
+          GSE.lgm_tot_p50, GSE.sfr_tot_p50, G.objID, GSI.specObjID
+        INTO mydb.SDSSspecgalsDR8 FROM SpecObj S CROSS APPLY
+          dbo.fGetNearestObjEQ(S.ra, S.dec, 0.06) N, Galaxy G,
+          GalSpecInfo GSI, GalSpecLine GSL, GalSpecIndx GSX, GalSpecExtra GSE
+        WHERE N.objID = G.objID
+          AND GSI.specObjID = S.specObjID
+          AND GSL.specObjID = S.specObjID
+          AND GSX.specObjID = S.specObjID
+          AND GSE.specObjID = S.specObjID
+          --- add some quality cuts to get rid of obviously bad measurements
+          AND (G.petroMag_r > 10 AND G.petroMag_r < 18)
+          AND (G.modelMag_u-G.modelMag_r) > 0
+          AND (G.modelMag_u-G.modelMag_r) < 6
+          AND (modelMag_u > 10 AND modelMag_u < 25)
+          AND (modelMag_g > 10 AND modelMag_g < 25)
+          AND (modelMag_r > 10 AND modelMag_r < 25)
+          AND (modelMag_i > 10 AND modelMag_i < 25)
+          AND (modelMag_z > 10 AND modelMag_z < 25)
+          AND S.rChi2 < 2
+          AND (S.zErr > 0 AND S.zErr < 0.01)
+          AND S.z > 0.02
+          --- end of query ---
+
+    Examples
+    --------
+    >>> from astroML.datasets import fetch_sdss_specgals
+    >>> data = fetch_sdss_specgals()
+    >>> data.shape  # number of objects in dataset
+    (661598,)
+    >>> data.names[:5]  # first five column names
+    ['ra', 'dec', 'mjd', 'plate', 'fiberID']
+    >>> print data['ra'][:3]  # first three RA values
+    [ 146.71419105  146.74414186  146.62857334]
+    >>> print data['dec'][:3]  #  first three declination values
+    [-1.04127639 -0.6522198  -0.7651468 ]
+    """
+    # fits is an optional dependency: don't import globally
+    from astropy.io import fits
+
+    data_home = get_data_home(data_home)
+    if not os.path.exists(data_home):
+        os.makedirs(data_home)
+
+    archive_file = os.path.join(data_home, os.path.basename(DATA_URL))
+
+    if not os.path.exists(archive_file):
+        if not download_if_missing:
+            raise IOError('data not present on disk. '
+                          'set download_if_missing=True to download')
+
+        fitsdata = download_with_progress_bar(DATA_URL)
+        open(archive_file, 'wb').write(fitsdata)
+
+    hdulist = fits.open(archive_file)
+    return np.asarray(hdulist[1].data)
+
+
+def fetch_great_wall(data_home=None, download_if_missing=True,
+                     xlim=(-375, -175), ylim=(-300, 200)):
+    """Get the 2D SDSS "Great Wall" distribution, following Cowan et al 2008
+
+    Parameters
+    ----------
+    data_home : optional, default=None
+        Specify another download and cache folder for the datasets. By default
+        all scikit learn data is stored in '~/astroML_data' subfolders.
+
+    download_if_missing : optional, default=True
+        If False, raise a IOError if the data is not locally available
+        instead of trying to download the data from the source site.
+
+    xlim, ylim : tuples or None
+        the limits in Mpc of the data: default values are the same as that
+        used for the plots in Cowan 2008.  If set to None, no cuts will
+        be performed.
+
+    Returns
+    -------
+    data : ndarray, shape = (Ngals, 2)
+        grid of projected (x, y) locations of galaxies in Mpc
+    """
+    # local imports so we don't need dependencies for loading module
+    from scipy.interpolate import interp1d
+
+    # We need some cosmological information to compute the r-band
+    #  absolute magnitudes.  Use astropy.cosmology if available,
+    #  fall back on the astroML version if not.  This gets a bit hacky
+    #  because they don't quite have the same interfact
+    try:
+        import astropy
+        ver = astropy.__version__.split('.')
+        if int(ver[0]) == 0 and int(ver[1]) < 3:
+            raise ImportError("Insufficient astropy version; using builtin")
+        from astropy.cosmology import FlatLambdaCDM
+        cosmo = FlatLambdaCDM(73.2, 0.27, Tcmb0=0)
+    except ImportError:
+        from ..cosmology import Cosmology
+        cosmo = Cosmology(omegaM=0.27, omegaL=0.73, h=0.732)
 
     data = fetch_sdss_specgals(data_home, download_if_missing)
 
@@ -140,12 +281,14 @@ def fetch_great_wall(data_home=None, download_if_missing=True,
     z = data['z']
     data = data[(z > 0.01) & (z < 0.12)]
 
-    # use redshift to compute absolute r-band magnitude
-    cosmo = Cosmology(omegaM=0.27, omegaL=0.73, h=0.732)
-
     # first sample the distance modulus on a grid
     zgrid = np.linspace(min(data['z']), max(data['z']), 100)
-    mugrid = np.array([cosmo.mu(z) for z in zgrid])
+    try:
+        # Astropy
+        mugrid = cosmo.distmod(z).value
+    except AttributeError:
+        # Built in
+        mugrid = np.array([cosmo.mu(z) for z in zgrid])
     f = interp1d(zgrid, mugrid)
     mu = f(data['z'])
 
@@ -155,7 +298,12 @@ def fetch_great_wall(data_home=None, download_if_missing=True,
 
     # compute distances in the equatorial plane
     # first sample comoving distance
-    Dcgrid = np.array([cosmo.Dc(z) for z in zgrid])
+    try:
+        # Astropy
+        Dcgrid = cosmo.comoving_distance(z).value
+    except AttributeError:
+        # Built in
+        Dcgrid = np.array([cosmo.Dc(z) for z in zgrid])
     f = interp1d(zgrid, Dcgrid)
     dist = f(data['z'])
 

--- a/astroML/datasets/sdss_specgals.py
+++ b/astroML/datasets/sdss_specgals.py
@@ -230,7 +230,7 @@ def fetch_sdss_specgals(data_home=None, download_if_missing=True):
 
 
 def fetch_great_wall(data_home=None, download_if_missing=True,
-                     xlim=(-375, -175), ylim=(-300, 200)):
+                     xlim=(-375, -175), ylim=(-300, 200), cosmo=None):
     """Get the 2D SDSS "Great Wall" distribution, following Cowan et al 2008
 
     Parameters
@@ -248,6 +248,10 @@ def fetch_great_wall(data_home=None, download_if_missing=True,
         used for the plots in Cowan 2008.  If set to None, no cuts will
         be performed.
 
+    cosmo : astropy.cosmology instance specifying cosmology
+        to use when generating the sample.  If not provided,
+        a Flat Lambda CDM model with h=0.732, Omega_m=0.27 is used.
+
     Returns
     -------
     data : ndarray, shape = (Ngals, 2)
@@ -257,19 +261,10 @@ def fetch_great_wall(data_home=None, download_if_missing=True,
     from scipy.interpolate import interp1d
 
     # We need some cosmological information to compute the r-band
-    #  absolute magnitudes.  Use astropy.cosmology if available,
-    #  fall back on the astroML version if not.  This gets a bit hacky
-    #  because they don't quite have the same interfact
-    try:
-        import astropy
-        ver = astropy.__version__.split('.')
-        if int(ver[0]) == 0 and int(ver[1]) < 3:
-            raise ImportError("Insufficient astropy version; using builtin")
-        from astropy.cosmology import FlatLambdaCDM
-        cosmo = FlatLambdaCDM(73.2, 0.27, Tcmb0=0)
-    except ImportError:
-        from ..cosmology import Cosmology
-        cosmo = Cosmology(omegaM=0.27, omegaL=0.73, h=0.732)
+    #  absolute magnitudes.
+    if cosmo is None:
+        import astropy.cosmology
+        cosmo = astropy.cosmology.FlatLambdaCDM(73.2, 0.27, Tcmb0=0)
 
     data = fetch_sdss_specgals(data_home, download_if_missing)
 
@@ -283,12 +278,7 @@ def fetch_great_wall(data_home=None, download_if_missing=True,
 
     # first sample the distance modulus on a grid
     zgrid = np.linspace(min(data['z']), max(data['z']), 100)
-    try:
-        # Astropy
-        mugrid = cosmo.distmod(z).value
-    except AttributeError:
-        # Built in
-        mugrid = np.array([cosmo.mu(z) for z in zgrid])
+    mugrid = cosmo.distmod(z).value
     f = interp1d(zgrid, mugrid)
     mu = f(data['z'])
 
@@ -298,12 +288,7 @@ def fetch_great_wall(data_home=None, download_if_missing=True,
 
     # compute distances in the equatorial plane
     # first sample comoving distance
-    try:
-        # Astropy
-        Dcgrid = cosmo.comoving_distance(z).value
-    except AttributeError:
-        # Built in
-        Dcgrid = np.array([cosmo.Dc(z) for z in zgrid])
+    Dcgrid = cosmo.comoving_distance(z).value
     f = interp1d(zgrid, Dcgrid)
     dist = f(data['z'])
 

--- a/book_figures/chapter4/fig_lyndenbell_gals.py
+++ b/book_figures/chapter4/fig_lyndenbell_gals.py
@@ -30,16 +30,8 @@ from scipy import interpolate, stats
 from astroML.lumfunc import binned_Cminus, bootstrap_Cminus
 from astroML.datasets import fetch_sdss_specgals
 
-try:
-    import astropy
-    ver = astropy.__version__.split('.')
-    if int(ver[0]) == 0 and int(ver[1]) < 3:
-        raise ImportError("Insufficient astropy version; using builtin")
-    from astropy.cosmology import FlatLambdaCDM
-    cosmo = FlatLambdaCDM(71, 0.27, Tcmb0=0)
-except ImportError:
-    from astroML.cosmology import Cosmology
-    cosmo = Cosmology()
+from astropy.cosmology import FlatLambdaCDM
+cosmo = FlatLambdaCDM(71, 0.27, Tcmb0=0)
 
 #----------------------------------------------------------------------
 # This function adjusts matplotlib settings for a uniform feel in the textbook.
@@ -83,13 +75,7 @@ print data_blue.size, "blue galaxies"
 #  We'll accomplish this using the cosmology class and
 #  scipy's cubic spline interpolation.
 z_sample = np.linspace(0.01, 1.5, 100)
-try:
-    # Astropy
-    mu_sample = cosmo.distmod(z_sample).value
-except AttributeError:
-    # Built in
-    mu_sample = [cosmo.mu(z) for z in z_sample]
-
+mu_sample = cosmo.distmod(z_sample).value
 mu_z = interpolate.interp1d(z_sample, mu_sample)
 z_mu = interpolate.interp1d(mu_sample, z_sample)
 

--- a/book_figures/chapter8/fig_gp_mu_z.py
+++ b/book_figures/chapter8/fig_gp_mu_z.py
@@ -21,16 +21,8 @@ from sklearn.gaussian_process import GaussianProcess
 
 from astroML.datasets import generate_mu_z
 
-# Use astropy cosmology if possible, built in if not
-try:
-    import astropy.cosmology
-    ver = astropy.__version__.split('.')
-    if int(ver[0]) == 0 and int(ver[1]) < 3:
-        raise ImportError("Insufficient astropy version; using builtin")
-    cosmo = astropy.cosmology.FlatLambdaCDM(71.0, 0.27, Tcmb0=0)
-except ImportError:
-    from astroML.cosmology import Cosmology
-    cosmo = Cosmology()
+import astropy.cosmology
+cosmo = astropy.cosmology.FlatLambdaCDM(71.0, 0.27, Tcmb0=0)
 
 #----------------------------------------------------------------------
 # This function adjusts matplotlib settings for a uniform feel in the textbook.
@@ -44,12 +36,7 @@ setup_text_plots(fontsize=8, usetex=True)
 # Generate data
 z_sample, mu_sample, dmu = generate_mu_z(size=100, random_state=0)
 z = np.linspace(0.01, 2, 1000)
-try:
-    # Astropy
-    mu_true = cosmo.distmod(z).value
-except AttributeError:
-    # Built in
-    mu_true = np.asarray(map(cosmo.mu, z))
+mu_true = cosmo.distmod(z).value
 
 #------------------------------------------------------------
 # fit the data

--- a/book_figures/chapter8/fig_nonlinear_mu_z.py
+++ b/book_figures/chapter8/fig_nonlinear_mu_z.py
@@ -18,6 +18,7 @@ show the input values.
 #    https://groups.google.com/forum/#!forum/astroml-general
 import numpy as np
 from matplotlib import pyplot as plt
+from astropy.cosmology import LambdaCDM
 
 from astroML.datasets import generate_mu_z
 from astroML.plotting.mcmc import convert_to_stdev
@@ -42,7 +43,6 @@ z_sample, mu_sample, dmu = generate_mu_z(size=100, z0=0.3,
 # define a function to compute the model predictued mu values
 #  from beta = [omegaM, omegaL]
 def compute_mu(beta, z):
-    from astropy.cosmology import LambdaCDM
     cosmo = LambdaCDM(71.0, beta[0], beta[1], Tcmb0=0)
     return cosmo.distmod(z).value
 

--- a/book_figures/chapter8/fig_rbf_ridge_mu_z.py
+++ b/book_figures/chapter8/fig_rbf_ridge_mu_z.py
@@ -29,16 +29,8 @@ from sklearn.linear_model import LinearRegression, Ridge, Lasso
 from astroML.datasets import generate_mu_z
 
 # Use astropy cosmology if possible, built in if not
-try:
-    import astropy
-    ver = astropy.__version__.split('.')
-    if int(ver[0]) == 0 and int(ver[1]) < 3:
-        raise ImportError("Insufficient astropy version; using builtin")
-    from astropy.cosmology import FlatLambdaCDM
-    cosmo = FlatLambdaCDM(71, 0.27, Tcmb0=0)
-except ImportError:
-    from astroML.cosmology import Cosmology
-    cosmo = Cosmology()
+from astropy.cosmology import FlatLambdaCDM
+cosmo = FlatLambdaCDM(71, 0.27, Tcmb0=0)
 
 #----------------------------------------------------------------------
 # This function adjusts matplotlib settings for a uniform feel in the textbook.
@@ -55,12 +47,8 @@ np.random.seed(0)
 z_sample, mu_sample, dmu = generate_mu_z(size=100, random_state=0)
 
 z = np.linspace(0.01, 2, 1000)
-try:
-    # Astropy
-    mu = cosmo.distmod(z).value
-except AttributeError:
-    # Built in
-    mu = np.asarray(map(cosmo.mu, z))
+mu = cosmo.distmod(z).value
+
 
 #------------------------------------------------------------
 # Manually convert data to a gaussian basis

--- a/book_figures/chapter8/fig_rbf_ridge_mu_z.py
+++ b/book_figures/chapter8/fig_rbf_ridge_mu_z.py
@@ -26,8 +26,19 @@ from scipy.stats import lognorm
 
 from sklearn.linear_model import LinearRegression, Ridge, Lasso
 
-from astroML.cosmology import Cosmology
 from astroML.datasets import generate_mu_z
+
+# Use astropy cosmology if possible, built in if not
+try:
+    import astropy
+    ver = astropy.__version__.split('.')
+    if int(ver[0]) == 0 and int(ver[1]) < 3:
+        raise ImportError("Insufficient astropy version; using builtin")
+    from astropy.cosmology import FlatLambdaCDM
+    cosmo = FlatLambdaCDM(71, 0.27, Tcmb0=0)
+except ImportError:
+    from astroML.cosmology import Cosmology
+    cosmo = Cosmology()
 
 #----------------------------------------------------------------------
 # This function adjusts matplotlib settings for a uniform feel in the textbook.
@@ -41,12 +52,15 @@ setup_text_plots(fontsize=8, usetex=True)
 # generate data
 np.random.seed(0)
 
-z_sample, mu_sample, dmu = generate_mu_z(100, random_state=0)
-cosmo = Cosmology()
+z_sample, mu_sample, dmu = generate_mu_z(size=100, random_state=0)
 
 z = np.linspace(0.01, 2, 1000)
-mu = np.asarray(map(cosmo.mu, z))
-
+try:
+    # Astropy
+    mu = cosmo.distmod(z).value
+except AttributeError:
+    # Built in
+    mu = np.asarray(map(cosmo.mu, z))
 
 #------------------------------------------------------------
 # Manually convert data to a gaussian basis

--- a/book_figures/chapter8/fig_rbf_ridge_mu_z.py
+++ b/book_figures/chapter8/fig_rbf_ridge_mu_z.py
@@ -28,7 +28,6 @@ from sklearn.linear_model import LinearRegression, Ridge, Lasso
 
 from astroML.datasets import generate_mu_z
 
-# Use astropy cosmology if possible, built in if not
 from astropy.cosmology import FlatLambdaCDM
 cosmo = FlatLambdaCDM(71, 0.27, Tcmb0=0)
 

--- a/book_figures/chapter8/fig_regression_mu_z.py
+++ b/book_figures/chapter8/fig_regression_mu_z.py
@@ -4,7 +4,7 @@ Cosmology Regression Example
 Figure 8.2
 
 Various regression fits to the distance modulus vs. redshift relation for a
-simulated set of 100 supernovae, selected from a distribution
+simulated set of 100 supernovas, selected from a distribution
 :math:`p(z) \propto (z/z_0)^2 \exp[(z/z_0)^{1.5}]` with :math:`z_0 = 0.3`.
 Gaussian basis functions have 15 Gaussians evenly spaced between z = 0 and 2,
 with widths of 0.14. Kernel regression uses a Gaussian kernel with width 0.1.

--- a/book_figures/chapter8/fig_regression_mu_z.py
+++ b/book_figures/chapter8/fig_regression_mu_z.py
@@ -24,17 +24,8 @@ from astroML.datasets import generate_mu_z
 from astroML.linear_model import LinearRegression, PolynomialRegression,\
     BasisFunctionRegression, NadarayaWatson
 
-# Use astropy cosmology if possible, built in if not
-try:
-    import astropy
-    ver = astropy.__version__.split('.')
-    if int(ver[0]) == 0 and int(ver[1]) < 3:
-        raise ImportError("Insufficient astropy version; using builtin")
-    from astropy.cosmology import FlatLambdaCDM
-    cosmo = FlatLambdaCDM(71, 0.27, Tcmb0=0)
-except ImportError:
-    from astroML.cosmology import Cosmology
-    cosmo = Cosmology()
+from astropy.cosmology import FlatLambdaCDM
+cosmo = FlatLambdaCDM(71, 0.27, Tcmb0=0)
 
 #----------------------------------------------------------------------
 # This function adjusts matplotlib settings for a uniform feel in the textbook.
@@ -47,13 +38,7 @@ setup_text_plots(fontsize=8, usetex=True)
 #------------------------------------------------------------
 z_sample, mu_sample, dmu = generate_mu_z(size=100, random_state=0)
 z = np.linspace(0.01, 2, 1000)
-
-try:
-    # Astropy
-    mu_true = cosmo.distmod(z).value
-except AttributeError:
-    # Built in
-    mu_true = np.asarray(map(cosmo.mu, z))
+mu_true = cosmo.distmod(z).value
 
 #------------------------------------------------------------
 # Define our classifiers


### PR DESCRIPTION
- Import astropy.cosmology when possible and use instead of
  built-in cosmology class.
- Add deprecation warning to built in cosmology
- astropy 0.3.0 or more recent required because the astropy.cosmology
  objects return things with units.  This -is- tested for;
  if the version is less than 0.3.0, the built in cosmology
  class is used instead.
- datasets/generate.generate_mu_z no longer supports optional
  **kwargs passed to cosmology object; this would be complicated
  to implement when using astropy.cosmology because it takes some
  positional (rather than named) arguments.  However, this option
  wasn't used in the figures anyways.
- Affected figures in the book tested to be the same in python 2.7:
  4.10, 8.2 8.4, 8.5, 8.11
- Nosetests pass.
