### PR TITLE
Use mixture weights when computing likelihoods

### DIFF
--- a/astroML/density_estimation/xdeconv.py
+++ b/astroML/density_estimation/xdeconv.py
@@ -126,7 +126,7 @@ class XDGMM(object):
         Xerr = Xerr[:, np.newaxis, :, :]
         T = Xerr + self.V
 
-        return log_multivariate_gaussian(X, self.mu, T)
+        return log_multivariate_gaussian(X, self.mu, T) + np.log(self.alpha)
 
     def logL(self, X, Xerr):
         """Compute the log-likelihood of data given the model


### PR DESCRIPTION
Likelihood calculation in xdeconv.py is missing component amplitudes, otherwise seems ok.