### PR TITLE
Adds counter increment to prevent infinite loop upon rebin all zero case

### DIFF
--- a/examples/datasets/compute_sdss_pca.py
+++ b/examples/datasets/compute_sdss_pca.py
@@ -73,6 +73,7 @@ def fetch_and_shift_spectra(n_spectra,
         if np.all(spec_rebin.spectrum == 0):
             num_skipped += 1
             print("%i, %i, %i is all zero" % (plate[i], mjd[i], fiber[i]))
+            i += 1
             continue
 
         spec_cln[i] = spec.spec_cln


### PR DESCRIPTION
Addresses issue raised in #60 by @kareemelbadry in which an infinite loop could be encountered during SDSS spectra resampling if rebinned to all zeros.

Submitting PR since issue has been idle for 1yr.  
