### PR TITLE
Relative imports in wrong order if you want to use histogram via

### DIFF
--- a/astroML/density_estimation/__init__.py
+++ b/astroML/density_estimation/__init__.py
@@ -1,7 +1,7 @@
 from .density_estimation import KDE, KNeighborsDensity
 from .xdeconv import XDGMM
+from .bayesian_blocks import bayesian_blocks
 from .histtools import\
     scotts_bin_width, freedman_bin_width, knuth_bin_width, histogram
-from .bayesian_blocks import bayesian_blocks
 from .empirical import FunctionDistribution, EmpiricalDistribution
 from .gauss_mixture import GaussianMixture1D


### PR DESCRIPTION
Reordered import so

``` python
from astroML.density_estimation import histogram
histogram(x, bins="blocks")
```

works
