### PR TITLE
fixed python 3.5 bug about invalid index => histograms w/ Knuth's rule

### DIFF
--- a/astroML/density_estimation/histtools.py
+++ b/astroML/density_estimation/histtools.py
@@ -102,8 +102,8 @@ def freedman_bin_width(data, return_bins=False):
         raise ValueError("data should have more than three entries")
 
     dsorted = np.sort(data)
-    v25 = dsorted[n // 4 - 1]
-    v75 = dsorted[(3 * n) // 4 - 1]
+    v25 = dsorted[int(n // 4 - 1)]
+    v75 = dsorted[int((3 * n) // 4 - 1)]
 
     dx = 2 * (v75 - v25) * 1. / (n ** (1. / 3))
 


### PR DESCRIPTION
When trying to plot histograms using the Knuth's rule with astroML
and Python 3.5, I was having a weird error. The error was in line 105 and
106 of `histtools.py`: invalid index. This bug prevented from plotting histograms with the Knuth's rule.

I fixed that with a simple integer conversion.