### PR TITLE
Updating sklearn's GMM to GaussianMixture.

### DIFF
--- a/astroML/classification/gmm_bayes.py
+++ b/astroML/classification/gmm_bayes.py
@@ -20,7 +20,7 @@ class GMMBayes(BaseNB):
     n_components : int or list
         number of components to use in the gmm.  If specified as a list, it
         must match the number of class labels
-    other keywords are passed directly to GMM
+    other keywords are passed directly to GaussianMixture
     """
     def __init__(self, n_components=1, **kwargs):
         self.n_components = np.atleast_1d(n_components)

--- a/astroML/classification/gmm_bayes.py
+++ b/astroML/classification/gmm_bayes.py
@@ -5,24 +5,21 @@ This implements generative classification based on mixtures of gaussians
 to model the probability density of each class.
 """
 import numpy as np
-from sklearn.mixture import GMM
+from sklearn.mixture import GaussianMixture as GMM
 from sklearn.naive_bayes import BaseNB
 
 
 class GMMBayes(BaseNB):
     """GMM Bayes Classifier
-
     This is a generalization to the Naive Bayes classifier: rather than
     modeling the distribution of each class with axis-aligned gaussians,
     GMMBayes models the distribution of each class with mixtures of
     gaussians.  This can lead to better classification in some cases.
-
     Parameters
     ----------
     n_components : int or list
         number of components to use in the gmm.  If specified as a list, it
         must match the number of class labels
-
     other keywords are passed directly to GMM
     """
     def __init__(self, n_components=1, **kwargs):
@@ -54,6 +51,14 @@ class GMMBayes(BaseNB):
         n_comp = np.zeros(len(self.classes_), dtype=int) + self.n_components
 
         for i, y_i in enumerate(unique_y):
+            if n_comp[i] > X[y == y_i].shape[0]:
+                import warnings
+                warnstr = ("Expected n_samples >= n_components but got "
+                           "n_samples={0}, n_components={1}, "
+                           "n_components set to {0}.")
+                warnings.warn(warnstr.format(X[y == y_i].shape[0], n_comp[i]))
+                n_comp[i] = y_i
+
             self.gmms_[i] = GMM(n_comp[i], **self.kwargs).fit(X[y == y_i])
             self.class_prior_[i] = np.float(np.sum(y == y_i)) / n_samples
 
@@ -61,5 +66,5 @@ class GMMBayes(BaseNB):
 
     def _joint_log_likelihood(self, X):
         X = np.asarray(np.atleast_2d(X))
-        logprobs = np.array([g.score(X) for g in self.gmms_]).T
+        logprobs = np.array([g.score_samples(X) for g in self.gmms_]).T
         return logprobs + np.log(self.class_prior_)


### PR DESCRIPTION
Updating Gaussian Mixture Model classifier to be concurrent with the new sklearn implementation `GaussianMixture`, apart from removing a barrage of warning messages, solves the problem of the sklearn `GMM` class getting deprecated as of sklearn version 0.2.

`GaussianMixture` does not correspond one-to-one with old `GMM` implementation.
Foreseeable consequences for code built on GMMBayes are:

  1. `min_covar` is replaced by `reg_covar` (instantiation). This will most likely trigger an error for any code built on `GMMBayes` that used old `GMM` class.

  1. Default GMM covariance_type is `full` instead of `diag`

  1. `GMM.covars_` is replaced by `GaussianMixture.covariances_` 

  1. `GMM.score` is replaced by `GaussianMixture.score_samples`

  1. `GaussianMixture` implementation limits the number of gaussian components to number of sample points they are fitted to. This did not seem to be the case with `GMM` therefore additional check is implemented and number of gaussian components of the model is now manually set to number of sample points if the number of gaussian components was larger than the number of sample points being fitted. A warning message is issued.

The results from `GaussianMixture` seem, on surface level, to correspond to results from `GMM`. Further testing desired.

I have not introduced any aliases for old keywords as per Python's philosophy - there should be only 1 obvious way to do it. AstroML's documentation points to sklean's documentation which won't have these keywords, leading to a potentially confusing situation.
