### PR TITLE
Rebased version of #35: Use astropy.cosmology instead of built-in cosmology when possible

### DIFF
--- a/astroML/cosmology.py
+++ b/astroML/cosmology.py
@@ -1,10 +1,12 @@
 import numpy as np
 from scipy import integrate
 
+from astroML.utils import deprecated
+from astroML.utils.exceptions import AstroMLDeprecationWarning
 
-import warnings
 
-
+@deprecated('0.4', alternative='astropy.cosmology',
+            warning_type=AstroMLDeprecationWarning)
 class Cosmology(object):
     """Class to enable simple cosmological calculations.
 
@@ -24,7 +26,6 @@ class Cosmology(object):
     [1] http://roban.github.com/CosmoloPy/
     """
     def __init__(self, omegaM=0.27, omegaL=0.73, h=0.71):
-        warnings.warn("deprecated; use astropy.cosmology", DeprecationWarning)
         self.omegaM = omegaM
         self.omegaL = omegaL
         self.omegaK = 1. - omegaM - omegaL

--- a/astroML/cosmology.py
+++ b/astroML/cosmology.py
@@ -2,6 +2,9 @@ import numpy as np
 from scipy import integrate
 
 
+import warnings
+
+
 class Cosmology(object):
     """Class to enable simple cosmological calculations.
 
@@ -21,6 +24,7 @@ class Cosmology(object):
     [1] http://roban.github.com/CosmoloPy/
     """
     def __init__(self, omegaM=0.27, omegaL=0.73, h=0.71):
+        warnings.warn("deprecated; use astropy.cosmology", DeprecationWarning)
         self.omegaM = omegaM
         self.omegaL = omegaL
         self.omegaK = 1. - omegaM - omegaL

--- a/astroML/datasets/generated.py
+++ b/astroML/datasets/generated.py
@@ -1,5 +1,4 @@
 import numpy as np
-from ..cosmology import Cosmology
 from ..density_estimation import FunctionDistribution
 from ..utils import check_random_state
 
@@ -9,37 +8,46 @@ def redshift_distribution(z, z0):
 
 
 def generate_mu_z(size=1000, z0=0.3, dmu_0=0.1, dmu_1=0.02,
-                  random_state=None, **kwargs):
+                  random_state=None, cosmo=None):
     """Generate a dataset of distance modulus vs redshift.
 
     Parameters
     ----------
     size : int or tuple
         size of generated data
+
     z0 : float
         parameter in redshift distribution:
         p(z) ~ (z / z0)^2 exp[-1.5 (z / z0)]
+
     dmu_0, dmu_1 : float
         specify the error in mu, dmu = dmu_0 + dmu_1 * mu
+
     random_state : None, int, or np.random.RandomState instance
         random seed or random number generator
-    **kwargs :
-        additional keyword arguments are passed to the Cosmology function
+
+    cosmo : astropy.cosmology instance specifying cosmology
+        to use when generating the sample.  If not provided,
+        a Flat Lambda CDM model with h=0.71, Omega_m=0.27 is used.
 
     Returns
     -------
     z, mu, dmu : ndarrays
         arrays of shape `size`
     """
-    random_state = check_random_state(random_state)
-    cosmo = Cosmology(**kwargs)
 
+    if cosmo is None:
+        import astropy.cosmology
+        cosmo = astropy.cosmology.FlatLambdaCDM(71, 0.27, Tcmb0=0)
+
+    random_state = check_random_state(random_state)
     zdist = FunctionDistribution(redshift_distribution, func_args=dict(z0=z0),
                                  xmin=0.1 * z0, xmax=10 * z0,
                                  random_state=random_state)
 
     z_sample = zdist.rvs(size)
-    mu_sample = np.reshape([cosmo.mu(z) for z in z_sample.ravel()], size)
+    mu_sample = cosmo.distmod(np.ravel(z_sample)).value.reshape(size)
+
     dmu = dmu_0 + dmu_1 * mu_sample
     mu_sample = random_state.normal(mu_sample, dmu)
 


### PR DESCRIPTION
This PR needs revision, and in it's current stage the rebased and squashed version of #35 with the removal of the figures.

Original commit message:

* Import astropy.cosmology when possible and use instead of
  built-in cosmology class.
* Add deprecation warning to built in cosmology
* astropy 0.3.0 or more recent required because the astropy.cosmology
  objects return things with units.  This -is- tested for;
  if the version is less than 0.3.0, the built in cosmology
  class is used instead.
* datasets/generate.generate_mu_z no longer supports optional
  **kwargs passed to cosmology object; this would be complicated
  to implement when using astropy.cosmology because it takes some
  positional (rather than named) arguments.  However, this option
  wasn't used in the figures anyways.
* Affected figures in the book tested to be the same:
   4.10, 8.2 8.4, 8.5, 8.11
* Nosetests pass.

Rather than fall back on built-in cosmology, just require astropy.cosmology

* Careful comparison shows that figure 8.3 (rbf_ridge) does not
  quite match that in the text in the left panel.  However, that
  is not the result of using astropy.cosmology, but rather seems to
  be some difference in scikit-learn.  Comparison with the master
  branch (so, using the built-in Cosmology class) produces an
  identical figure to the one produced by this branch.
* Change deprecation warning to recommend using astropy.cosmology
* Add optional arguments to generate_mu_z and fetch_great_wall
  to allow callers to provide their own cosmology, while keeping
  the same defaults.

Fix horrible pasting error in sdss_specgals, a few other minor adjustments.