### PR TITLE
Fixing numpy compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ matrix:
     fast_finish: true
 
     include:
-        - env: NUMPY_VERSION=1.15 PYTHON_VERSION=3.7
+        - env: NUMPY_VERSION=1.15
 
-        - env: NUMPY_VERSION=1.14 PYTHON_VERSION=3.7
+        - env: NUMPY_VERSION=1.14
 
         - env: NUMPY_VERSION=1.13
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,15 @@ matrix:
     fast_finish: true
 
     include:
-        - env: NUMPY_VERSION=1.11
+        - env: NUMPY_VERSION=1.15 PYTHON_VERSION=3.7
 
-        - env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
+        - env: NUMPY_VERSION=1.14 PYTHON_VERSION=3.7
 
-        - env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
+        - env: NUMPY_VERSION=1.13
+
+        - env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
+
+        - env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.10 SCIKIT_LEARN_VERSION=0.18
 
         - env: PYTHON_VERSION=2.7
 

--- a/astroML/filters.py
+++ b/astroML/filters.py
@@ -183,7 +183,7 @@ def wiener_filter(t, h, signal='gaussian', noise='flat', return_PSDs=False,
     # fit signal/noise params if necessary
     if signal_params is None:
         amp_guess = np.max(PSD[1:])
-        width_guess = np.min(np.abs(f[PSD[1:] < np.mean(PSD[1:])]))
+        width_guess = np.min(np.abs(f[PSD < np.mean(PSD[1:])]))
         signal_params = (amp_guess, width_guess)
     if noise_params is None:
         noise_params = (np.mean(PSD[1:]),)


### PR DESCRIPTION
This PR fixes the numpy incompatibility issue surfaced by the tests. 

Tests with newer python and numpy run locally (when tried on top of the fixes from #125), but there may still be some issues when backporting to 0.3.1