### PR TITLE
Testing with dev versions of dependenecies and adding OSX testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,15 +28,16 @@ matrix:
     include:
         - env: NUMPY_VERSION=1.15
 
-        - env: NUMPY_VERSION=1.14
+          env: NUMPY_VERSION=1.14
 
         - env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.13
 
         - env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.12
 
-        - env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
+        - os: osx
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
 
-        - env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.10 SCIKIT_LEARN_VERSION=0.18
+        - env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10 SCIKIT_LEARN_VERSION=0.18
 
         - env: PYTHON_VERSION=3.4 CONDA_DEPENDENCIES='scipy matplotlib pymc' NUMPY_VERSION=1.9
                PIP_DEPENDENCIES='astropy==2.0.9 scikit-learn==0.18'

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,15 @@ matrix:
 
         - env: PYTHON_VERSION=2.7
 
+        # Testing all the devs. This is expected to generate failures from time to time,
+        # and should also be run from cron.
+        - env: NUMPY_VERSION=dev ASTROPY_VERSION=dev SCIKIT_LEARN_VERSION=dev
+               SCIPY_VERSION=dev MATPLOTLIB_VERSION=dev
+
+    allow_failures:
+        - env: NUMPY_VERSION=dev ASTROPY_VERSION=dev SCIKIT_LEARN_VERSION=dev
+               SCIPY_VERSION=dev MATPLOTLIB_VERSION=dev
+
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh


### PR DESCRIPTION
This PR entirely depends on upstream infrastructure (https://github.com/astropy/ci-helpers/pull/352). 

Also, this job may take a long time to build so running into a travis timeout wouldn't be a huge surprise, but if that's the case, then addressing https://github.com/astropy/astropy/issues/8197 can become a higher priority.