### PR TITLE
Rewriting yield-based tests 

### DIFF
--- a/astroML/density_estimation/tests/test_density.py
+++ b/astroML/density_estimation/tests/test_density.py
@@ -1,20 +1,19 @@
 """
 Test density estimation techniques
 """
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from scipy.stats import norm
 from astroML.density_estimation import KNeighborsDensity, GaussianMixture1D
 
 
-def check_1D_density(clf, X, X2, true_dens, atol):
-    clf.fit(X)
-    dens = clf.eval(X2)
-
-    assert_allclose(dens, true_dens, atol=atol)
+classifiers = [KNeighborsDensity(method='simple', n_neighbors=250),
+               KNeighborsDensity(method='bayesian', n_neighbors=250)]
 
 
-def test_1D_density():
+@pytest.mark.parametrize("clf", classifiers)
+def test_1D_density(clf, atol=100):
     np.random.seed(0)
     dist = norm(0, 1)
 
@@ -22,11 +21,10 @@ def test_1D_density():
     X2 = np.linspace(-5, 5, 10).reshape((10, 1))
     true_dens = dist.pdf(X2[:, 0]) * X.shape[0]
 
-    classifiers = [KNeighborsDensity(method='simple', n_neighbors=250),
-                   KNeighborsDensity(method='bayesian', n_neighbors=250)]
+    clf.fit(X)
+    dens = clf.eval(X2)
 
-    for clf in classifiers:
-        yield (check_1D_density, clf, X, X2, true_dens, 100)
+    assert_allclose(dens, true_dens, atol=atol)
 
 
 def test_gaussian1d():

--- a/astroML/density_estimation/tests/test_xdeconv.py
+++ b/astroML/density_estimation/tests/test_xdeconv.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astroML.density_estimation import XDGMM
@@ -20,7 +21,8 @@ def test_XDGMM_1D_gaussian(N=100, sigma=0.1):
     assert_allclose(V, xdgmm.V[0], atol=0.1)
 
 
-def check_single_gaussian(N=100, D=3, sigma=0.1):
+@pytest.mark.parametrize("D", [1, 2, 3])
+def test_single_gaussian(D, N=100, sigma=0.1):
     np.random.seed(0)
     mu = np.random.random(D)
     V = np.random.random((D, D))
@@ -39,8 +41,3 @@ def check_single_gaussian(N=100, D=3, sigma=0.1):
     # but not identical.  We'll use a fudge factor of 0.1
     assert_allclose(mu, xdgmm.mu[0], atol=0.1)
     assert_allclose(V, xdgmm.V[0], atol=0.1)
-
-
-def test_single_gaussian(N=100, sigma=0.1):
-    for D in (1, 2, 3):
-        yield (check_single_gaussian, N, D, sigma)

--- a/astroML/tests/test_fourier.py
+++ b/astroML/tests/test_fourier.py
@@ -1,22 +1,19 @@
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astroML.fourier import\
     FT_continuous, IFT_continuous, PSD_continuous, sinegauss, sinegauss_FT
 
 
-def check_wavelets(t0, f0, Q, t):
+@pytest.mark.parametrize('t0', [-1, 0, 1])
+@pytest.mark.parametrize('f0', [1, 2])
+@pytest.mark.parametrize('Q', [1, 2])
+def test_wavelets(t0, f0, Q):
+    t = np.linspace(-10, 10, 10000)
     h = sinegauss(t, t0, f0, Q)
     f, H = FT_continuous(t, h)
     H2 = sinegauss_FT(f, t0, f0, Q)
     assert_allclose(H, H2, atol=1E-8)
-
-
-def test_wavelets():
-    t = np.linspace(-10, 10, 10000)
-    for t0 in (-1, 0, 1):
-        for f0 in (1, 2):
-            for Q in (1, 2):
-                yield (check_wavelets, t0, f0, Q, t)
 
 
 def sinegauss(t, t0, f0, a):
@@ -43,49 +40,37 @@ def sinegauss_PSD(f, t0, f0, a):
     return Pf + Pmf
 
 
-def check_FT_continuous(a, t0, f0, method, t):
+@pytest.mark.parametrize('a', [1, 2])
+@pytest.mark.parametrize('t0', [-2, 0, 2])
+@pytest.mark.parametrize('f0', [-1, 0, 1])
+@pytest.mark.parametrize('method', [1, 2])
+def test_FT_continuous(a, t0, f0, method):
+    t = np.linspace(-9, 10, 10000)
     h = sinegauss(t, t0, f0, a)
     f, H = FT_continuous(t, h, method=method)
     assert_allclose(H, sinegauss_FT(f, t0, f0, a), atol=1E-12)
 
 
-def test_FT_continuous():
+@pytest.mark.parametrize('a', [1, 2])
+@pytest.mark.parametrize('t0', [-2, 0, 2])
+@pytest.mark.parametrize('f0', [-1, 0, 1])
+@pytest.mark.parametrize('method', [1, 2])
+def test_PSD_continuous(a, t0, f0, method):
     t = np.linspace(-9, 10, 10000)
-    for a in (1, 2):
-        for t0 in (-2, 0, 2):
-            for f0 in (-1, 0, 1):
-                for method in (1, 2):
-                    yield (check_FT_continuous, a, t0, f0, method, t)
-
-
-def check_PSD_continuous(a, t0, f0, method, t):
     h = sinegauss(t, t0, f0, a)
     f, P = PSD_continuous(t, h, method=method)
     assert_allclose(P, sinegauss_PSD(f, t0, f0, a), atol=1E-12)
 
 
-def test_PSD_continuous():
-    t = np.linspace(-9, 10, 10000)
-    for a in (1, 2):
-        for t0 in (-2, 0, 2):
-            for f0 in (-1, 0, 1):
-                for method in (1, 2):
-                    yield (check_PSD_continuous, a, t0, f0, method, t)
-
-
-def check_IFT_continuous(a, t0, f0, method, f):
+@pytest.mark.parametrize('a', [1, 2])
+@pytest.mark.parametrize('t0', [-2, 0, 2])
+@pytest.mark.parametrize('f0', [-1, 0, 1])
+@pytest.mark.parametrize('method', [1, 2])
+def check_IFT_continuous(a, t0, f0, method):
+    f = np.linspace(-9, 10, 10000)
     H = sinegauss_FT(f, t0, f0, a)
     t, h = IFT_continuous(f, H, method=method)
     assert_allclose(h, sinegauss(t, t0, f0, a), atol=1E-12)
-
-
-def test_IFT_continuous():
-    f = np.linspace(-9, 10, 10000)
-    for a in (1, 2):
-        for t0 in (-2, 0, 2):
-            for f0 in (-1, 0, 1):
-                for method in (1, 2):
-                    yield (check_IFT_continuous, a, t0, f0, method, f)
 
 
 def test_IFT_FT():

--- a/astroML/time_series/tests/test_generate.py
+++ b/astroML/time_series/tests/test_generate.py
@@ -1,21 +1,18 @@
+import pytest
 import numpy as np
 from numpy.testing import assert_, assert_almost_equal
 from astroML.time_series import generate_power_law, generate_damped_RW
 
 
-def check_generate_args(N, dt, beta, generate_complex):
+@pytest.mark.parametrize("N", [10, 11])
+@pytest.mark.parametrize("generate_complex", [True, False])
+def test_generate_args(N, generate_complex):
+    dt = 0.1
+    beta = 2
     x = generate_power_law(N, dt, beta, generate_complex)
 
     assert_(bool(generate_complex) == np.iscomplexobj(x))
     assert_(len(x) == N)
-
-
-def test_generate_args():
-    dt = 0.1
-    beta = 2
-    for N in [10, 11]:
-        for generate_complex in [True, False]:
-            yield (check_generate_args, N, dt, beta, generate_complex)
 
 
 def test_generate_RW():


### PR DESCRIPTION
They are deprecated in pytest 3, so this PR rewrites them to use parametrize instead.