### PR TITLE
Deprecate histograms

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ The core ``astroML`` package requires the following:
 - Scipy_ >= 0.7
 - Scikit-learn_ >= 0.18
 - Matplotlib_ >= 0.99
-- AstroPy_ > 0.2.5
+- AstroPy_ >= 1.1
   AstroPy is required to read Flexible Image Transport
   System (FITS) files, which are used by several datasets.
 

--- a/astroML/density_estimation/bayesian_blocks.py
+++ b/astroML/density_estimation/bayesian_blocks.py
@@ -13,7 +13,12 @@ References
 import numpy as np
 # TODO: implement other fitness functions from appendix B of Scargle 2012
 
+from astroML.utils import deprecated
+from astroML.utils.exceptions import AstroMLDeprecationWarning
 
+
+@deprecated('0.4', alternative='astropy.stats.FitnessFunc',
+            warning_type=AstroMLDeprecationWarning)
 class FitnessFunc(object):
     """Base class for fitness functions
 
@@ -63,6 +68,8 @@ class FitnessFunc(object):
             return self.fitness.__code__.co_varnames[1:]
 
 
+@deprecated('0.4', alternative='astropy.stats.Events',
+            warning_type=AstroMLDeprecationWarning)
 class Events(FitnessFunc):
     """Fitness for binned or unbinned events
 
@@ -87,6 +94,8 @@ class Events(FitnessFunc):
             return 4 - np.log(73.53 * self.p0 * (N ** -0.478))
 
 
+@deprecated('0.4', alternative='astropy.stats.RegularEvents',
+            warning_type=AstroMLDeprecationWarning)
 class RegularEvents(FitnessFunc):
     """Fitness for regular events
 
@@ -129,6 +138,8 @@ class RegularEvents(FitnessFunc):
         return N_k * np.log(N_over_M) + (M_k - N_k) * np.log(one_m_NM)
 
 
+@deprecated('0.4', alternative='astropy.stats.PointMeasures',
+            warning_type=AstroMLDeprecationWarning)
 class PointMeasures(FitnessFunc):
     """Fitness for point measures
 
@@ -157,6 +168,8 @@ class PointMeasures(FitnessFunc):
             return 1.32 + 0.577 * np.log10(N)
 
 
+@deprecated('0.4', alternative='astropy.stats.bayesian_blocks',
+            warning_type=AstroMLDeprecationWarning)
 def bayesian_blocks(t, x=None, sigma=None,
                     fitness='events', **kwargs):
     """Bayesian Blocks Implementation

--- a/astroML/density_estimation/tests/test_bayesian_blocks.py
+++ b/astroML/density_estimation/tests/test_bayesian_blocks.py
@@ -1,6 +1,10 @@
 import numpy as np
-from  numpy.testing import assert_allclose, assert_
+from numpy.testing import assert_allclose, assert_
+
+from astropy.tests.helper import catch_warnings
+
 from astroML.density_estimation import bayesian_blocks
+from astroML.utils.exceptions import AstroMLDeprecationWarning
 
 
 def test_single_change_point():
@@ -8,7 +12,8 @@ def test_single_change_point():
     x = np.concatenate([np.random.random(100),
                         1 + np.random.random(200)])
 
-    bins = bayesian_blocks(x)
+    with catch_warnings(AstroMLDeprecationWarning):
+        bins = bayesian_blocks(x)
 
     assert_(len(bins) == 3)
     assert_allclose(bins[1], 1, rtol=0.02)
@@ -21,8 +26,9 @@ def test_duplicate_events():
     x = np.ones_like(t)
     x[:20] += 1
 
-    bins1 = bayesian_blocks(t)
-    bins2 = bayesian_blocks(t[:80], x[:80])
+    with catch_warnings(AstroMLDeprecationWarning):
+        bins1 = bayesian_blocks(t)
+        bins2 = bayesian_blocks(t[:80], x[:80])
 
     assert_allclose(bins1, bins2)
 
@@ -34,7 +40,8 @@ def test_measures_fitness_homoscedastic():
     sigma = 0.05
     x = np.random.normal(x, sigma)
 
-    bins = bayesian_blocks(t, x, sigma, fitness='measures')
+    with catch_warnings(AstroMLDeprecationWarning):
+        bins = bayesian_blocks(t, x, sigma, fitness='measures')
 
     assert_allclose(bins, [0, 0.45, 0.55, 1])
 
@@ -46,7 +53,8 @@ def test_measures_fitness_heteroscedastic():
     sigma = 0.02 + 0.02 * np.random.random(len(x))
     x = np.random.normal(x, sigma)
 
-    bins = bayesian_blocks(t, x, sigma, fitness='measures')
+    with catch_warnings(AstroMLDeprecationWarning):
+        bins = bayesian_blocks(t, x, sigma, fitness='measures')
 
     assert_allclose(bins, [0, 0.45, 0.55, 1])
 
@@ -58,7 +66,8 @@ def test_regular_events():
                             np.unique(np.random.randint(500, 1000, 200))])
     t = dt * steps
 
-    bins = bayesian_blocks(t, fitness='regular_events', dt=dt)
+    with catch_warnings(AstroMLDeprecationWarning):
+        bins = bayesian_blocks(t, fitness='regular_events', dt=dt)
 
     assert_(len(bins) == 3)
     assert_allclose(bins[1], 5, rtol=0.05)

--- a/astroML/density_estimation/tests/test_hist_binwidth.py
+++ b/astroML/density_estimation/tests/test_hist_binwidth.py
@@ -2,22 +2,28 @@ from __future__ import division
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_
+
+from astropy.tests.helper import catch_warnings
+
 from astroML.density_estimation import \
     scotts_bin_width, freedman_bin_width, knuth_bin_width, histogram
+from astroML.utils.exceptions import AstroMLDeprecationWarning
 
 
 def test_scotts_bin_width(N=10000, rseed=0):
     np.random.seed(rseed)
     X = np.random.normal(size=N)
-    delta = scotts_bin_width(X)
+    with catch_warnings(AstroMLDeprecationWarning):
+        delta = scotts_bin_width(X)
 
-    assert_allclose(delta,  3.5 * np.std(X) / N ** (1. / 3))
+    assert_allclose(delta, 3.5 * np.std(X) / N ** (1. / 3))
 
 
 def test_freedman_bin_width(N=10000, rseed=0):
     np.random.seed(rseed)
     X = np.random.normal(size=N)
-    delta = freedman_bin_width(X)
+    with catch_warnings(AstroMLDeprecationWarning):
+        delta = freedman_bin_width(X)
 
     indices = np.argsort(X)
     i25 = indices[N // 4 - 1]
@@ -29,7 +35,8 @@ def test_freedman_bin_width(N=10000, rseed=0):
 def test_knuth_bin_width(N=10000, rseed=0):
     np.random.seed(0)
     X = np.random.normal(size=N)
-    dx, bins = knuth_bin_width(X, return_bins=True)
+    with catch_warnings(AstroMLDeprecationWarning):
+        dx, bins = knuth_bin_width(X, return_bins=True)
     assert_allclose(len(bins), 59)
 
 
@@ -39,6 +46,7 @@ def test_histogram(N=1000, rseed=0):
 
     for bins in [30, np.linspace(-5, 5, 31),
                  'knuth', 'scotts', 'freedman']:
-        counts, bins = histogram(x, bins)
+        with catch_warnings(AstroMLDeprecationWarning):
+            counts, bins = histogram(x, bins)
         assert_(counts.sum() == len(x))
         assert_(len(counts) == len(bins) - 1)

--- a/astroML/density_estimation/tests/test_hist_binwidth.py
+++ b/astroML/density_estimation/tests/test_hist_binwidth.py
@@ -25,11 +25,9 @@ def test_freedman_bin_width(N=10000, rseed=0):
     with catch_warnings(AstroMLDeprecationWarning):
         delta = freedman_bin_width(X)
 
-    indices = np.argsort(X)
-    i25 = indices[N // 4 - 1]
-    i75 = indices[(3 * N) // 4 - 1]
+    v25, v75 = np.percentile(X, [25, 75])
 
-    assert_allclose(delta, 2 * (X[i75] - X[i25]) / N ** (1. / 3))
+    assert_allclose(delta, 2 * (v75 - v25) / N ** (1. / 3))
 
 
 def test_knuth_bin_width(N=10000, rseed=0):

--- a/astroML/plotting/hist_tools.py
+++ b/astroML/plotting/hist_tools.py
@@ -2,11 +2,15 @@ import warnings
 
 import numpy as np
 
-from astroML.density_estimation import\
-    scotts_bin_width, freedman_bin_width,\
-    knuth_bin_width, bayesian_blocks
+from astropy.stats import (scott_bin_width, freedman_bin_width,
+                           knuth_bin_width, bayesian_blocks)
+
+from astroML.utils import deprecated
+from astroML.utils.exceptions import AstroMLDeprecationWarning
 
 
+@deprecated('0.4', alternative='astropy.visualization.hist',
+            warning_type=AstroMLDeprecationWarning)
 def hist(x, bins=10, range=None, *args, **kwargs):
     """Enhanced histogram
 
@@ -65,7 +69,7 @@ def hist(x, bins=10, range=None, *args, **kwargs):
     elif bins in ['knuth', 'knuths']:
         dx, bins = knuth_bin_width(x, True, disp=False)
     elif bins in ['scott', 'scotts']:
-        dx, bins = scotts_bin_width(x, True)
+        dx, bins = scott_bin_width(x, True)
     elif bins in ['freedman', 'freedmans']:
         dx, bins = freedman_bin_width(x, True)
     elif isinstance(bins, str):

--- a/doc/user_guide/installation.rst
+++ b/doc/user_guide/installation.rst
@@ -113,7 +113,7 @@ The core ``astroML`` package requires the following:
 - `Scipy <http://www.scipy.org/>`_ >= 0.7
 - `scikit-learn <http://scikit-learn.org/>`_ >= 0.18
 - `matplotlib <http://matplotlib.org/>`_ >= 0.99
-- `astropy <http://www.astropy.org/>`_ >= 0.2.5
+- `astropy <http://www.astropy.org/>`_ >= 1.1
   AstroPy is required to read Flexible Image Transport
   System (FITS) files, which are used by several datasets.
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = ['scikit-learn>=0.18',
                     'numpy>=1.4',
                     'scipy>=0.7',
                     'matplotlib>=0.99',
-                    'astropy>=0.2.5']
+                    'astropy>=1.1']
 
 setup(name=NAME,
       version=VERSION,


### PR DESCRIPTION
Bayesian blocks has been ported to astropy v1.1 in https://github.com/astropy/astropy/pull/3756. 

This is based on #141, and thus should be rebased once that one is merged.

