### PR TITLE
Adding docs build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ sudo: false
 
 os: linux
 
-# The apt packages below are needed for sphinx builds. A full list of
-# packages that can be included can be found here:
-# https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
 addons:
     apt:
         packages:
@@ -17,10 +14,12 @@ env:
     global:
         - PYTHON_VERSION=3.7
         - ASTROPY_VERSION=stable
+        - NUMPY_VERSION=stable
         - CONDA_DEPENDENCIES='scipy scikit-learn matplotlib pymc'
         - PIP_DEPENDENCIES='astroML_addons'
         - DEBUG=true
         - PYTEST_VERSION='<4'
+        - SCRIPT_CMD='pytest astroML'
 
 matrix:
     fast_finish: true
@@ -43,10 +42,12 @@ matrix:
 
         - env: PYTHON_VERSION=2.7
 
+        - env: PYTHON_VERSION=3.6 SCRIPT_CMD='make -C doc html' PIP_DEPENDENCIES='sphinx astroML_addons'
+
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
     - python setup.py install
 
 script:
-    - pytest astroML
+    - $SCRIPT_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
         - NUMPY_VERSION=stable
         - CONDA_DEPENDENCIES='scipy scikit-learn matplotlib pymc'
         - PIP_DEPENDENCIES='astroML_addons'
-        - DEBUG=true
+        - DEBUG=True
         - PYTEST_VERSION='<4'
         - SCRIPT_CMD='pytest astroML'
 


### PR DESCRIPTION
The docs build should pass, so adding it to CI. Currently there are tons of warnings due to broken references to the book figures, those need to be fixed.