### PR TITLE
Some more histogram related fix

### DIFF
--- a/astroML/density_estimation/histtools.py
+++ b/astroML/density_estimation/histtools.py
@@ -253,15 +253,16 @@ def histogram(a, bins=10, range=None, **kwargs):
                                         'scotts', 'freedman'])):
         a = a[(a >= range[0]) & (a <= range[1])]
 
-    if bins == 'blocks':
-        bins = astropy_stats.bayesian_blocks(a)
-    elif bins == 'knuth':
-        da, bins = astropy_stats.knuth_bin_width(a, True)
-    elif bins == 'scotts':
-        da, bins = astropy_stats.scott_bin_width(a, True)
-    elif bins == 'freedman':
-        da, bins = astropy_stats.freedman_bin_width(a, True)
-    elif isinstance(bins, str):
-        raise ValueError("unrecognized bin code: '%s'" % bins)
+    if isinstance(bins, str):
+        if bins == 'blocks':
+            bins = astropy_stats.bayesian_blocks(a)
+        elif bins == 'knuth':
+            da, bins = astropy_stats.knuth_bin_width(a, True)
+        elif bins == 'scotts':
+            da, bins = astropy_stats.scott_bin_width(a, True)
+        elif bins == 'freedman':
+            da, bins = astropy_stats.freedman_bin_width(a, True)
+        else:
+            raise ValueError("unrecognized bin code: '{}'".format(bins))
 
     return np.histogram(a, bins, range, **kwargs)

--- a/astroML/plotting/hist_tools.py
+++ b/astroML/plotting/hist_tools.py
@@ -67,12 +67,12 @@ def hist(x, bins=10, range=None, *args, **kwargs):
     if bins in ['blocks']:
         bins = bayesian_blocks(x)
     elif bins in ['knuth', 'knuths']:
-        dx, bins = knuth_bin_width(x, True, disp=False)
+        dx, bins = knuth_bin_width(x, True)
     elif bins in ['scott', 'scotts']:
         dx, bins = scott_bin_width(x, True)
     elif bins in ['freedman', 'freedmans']:
         dx, bins = freedman_bin_width(x, True)
     elif isinstance(bins, str):
-        raise ValueError("unrecognized bin code: '%s'" % bins)
+        raise ValueError("unrecognized bin code: '{}'".format(bins))
 
     return ax.hist(x, bins, range, **kwargs)


### PR DESCRIPTION
Leaving the `disp` kwarg was a mistake, it should have been removed in #142. The rest of the changes mostly cosmetic to clean up a few warnings.