### PR TITLE
Make the example_builder sphinxext python3 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: generic
+language: minimal
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -9,6 +9,8 @@ addons:
     apt:
         packages:
             - gfortran
+            - texlive-latex-extra
+            - dvipng
 
 env:
     global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
             - gfortran
             - texlive-latex-extra
             - dvipng
+            - texlive-fonts-recommended
 
 env:
     global:

--- a/doc/sphinxext/example_builder.py
+++ b/doc/sphinxext/example_builder.py
@@ -246,9 +246,9 @@ class ExecFile(object):
             sys.stdout = self
 
             # execute the file
-            execfile(os.path.basename(self.filename), {'pl' : plt,
-                                                       'plt' : plt,
-                                                       'pylab' : plt})
+            with open(os.path.basename(self.filename)) as f:
+                code = compile(f.read(), "somefile.py", 'exec')
+                exec(code, {'pl': plt, 'plt': plt, 'pylab': plt})
 
             fig_mgr_list = matplotlib._pylab_helpers.Gcf.get_all_fig_managers()
             self.figlist = [manager.canvas.figure for manager in fig_mgr_list]


### PR DESCRIPTION
This has been left out previously.