### PR TITLE
Don't print the message for the minimization

### DIFF
--- a/astroML/filters.py
+++ b/astroML/filters.py
@@ -203,7 +203,7 @@ def wiener_filter(t, h, signal='gaussian', noise='flat', return_PSDs=False,
     min_func = lambda v: np.sum((PSD[1:] - signal(f[1:], v[0], v[1])
                                  - noise(f[1:], v[2])) ** 2)
     v0 = tuple(signal_params) + tuple(noise_params)
-    v = optimize.fmin(min_func, v0)
+    v = optimize.fmin(min_func, v0, disp=False)
 
     P_S = signal(f, v[0], v[1])
     P_N = noise(f, v[2])


### PR DESCRIPTION
The default scipy behaviour is not consistent for all the optimization method and the other filters in `astroML.filters` don't display info messages, so I opted to turn off it here, too.

If anyone was relying on this info being displayed we can introduce a `verbose` kwarg to provide it.