### PR TITLE
Moving data from UW websites to GitHub

### DIFF
--- a/astroML/datasets/LIGO_bigdog.py
+++ b/astroML/datasets/LIGO_bigdog.py
@@ -11,8 +11,8 @@ import numpy as np
 from . import get_data_home
 from .tools import download_with_progress_bar
 
-DATA_URL_LARGE = ('http://www.astro.washington.edu/users/ivezic/'
-                  'DMbook/LIGO/hoft.968653908-968655956.H1.dat.gz')
+DATA_URL_LARGE = ('https://github.com/astroML/astroML-data/raw/master/datasets/'
+                  'hoft.968653908-968655956.H1.dat.gz')
 LOCAL_FILE_LARGE = 'LIGO_large.npy'
 
 DATA_URL = 'http://www.ligo.org/science/GW100916/HLV-strain.txt'

--- a/astroML/datasets/LIGO_bigdog.py
+++ b/astroML/datasets/LIGO_bigdog.py
@@ -26,7 +26,7 @@ def fetch_LIGO_large(data_home=None, download_if_missing=True):
     ----------
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all astroML data is stored in '~/astroML_data'.
 
     download_if_missing : optional, default=True
         If False, raise a IOError if the data is not locally available
@@ -72,7 +72,7 @@ def fetch_LIGO_bigdog(data_home=None, download_if_missing=True):
     ----------
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all astroML data is stored in '~/astroML_data'.
 
     download_if_missing : optional, default=True
         If False, raise a IOError if the data is not locally available

--- a/astroML/datasets/LINEAR_sample.py
+++ b/astroML/datasets/LINEAR_sample.py
@@ -1,26 +1,18 @@
 import os
-from ..py3k_compat import BytesIO
 import tarfile
 
 import numpy as np
+from astropy.table import Table
 
 from . import get_data_home
 from .tools import download_with_progress_bar
 
-TARGETLIST_URL = ("http://www.astro.washington.edu/users/ivezic/"
-                  "linear/allDataFinal/allLINEARfinal_targets.dat")
-DATA_URL = ("http://www.astro.washington.edu/users/ivezic/"
-            "linear/allDataFinal/allLINEARfinal_dat.tar.gz")
-
-# old version of the data
-# GENEVA_URL = ("http://www.astro.washington.edu/users/ivezic/"
-#              "DMbook/data/LINEARattributes.dat"
-#GENEVA_ARCHIVE = 'LINEARattributes.npy'
-# ARCHIVE_DTYPE = [(s, 'f8') for s in ('RA', 'Dec', 'ug', 'gi', 'iK',
-#                                     'JK', 'logP', 'amp', 'skew')]
-
-GENEVA_URL = ("http://www.astro.washington.edu/users/ivezic/"
-              "DMbook/data/LINEARattributesFinalApr2013.dat")
+TARGETLIST_URL = ("https://github.com/astroML/astroML-data/raw/master/datasets/"
+                  "allLINEARfinal_targets.dat.gz")
+DATA_URL = ("https://github.com/astroML/astroML-data/raw/master/datasets/"
+            "allLINEARfinal_dat.tar.gz")
+GENEVA_URL = ("https://github.com/astroML/astroML-data/raw/master/datasets/"
+              "LINEARattributesFinalApr2013.dat.gz")
 GENEVA_ARCHIVE = 'LINEARattributesFinalApr2013.npy'
 ARCHIVE_DTYPE = ([(s, 'f8') for s in ('RA', 'Dec', 'ug', 'gi', 'iK',
                                       'JK', 'logP', 'amp', 'skew',
@@ -193,8 +185,8 @@ def fetch_LINEAR_geneva(data_home=None, download_if_missing=True):
             raise IOError('data not present on disk. '
                           'set download_if_missing=True to download')
 
-        databuffer = download_with_progress_bar(GENEVA_URL)
-        data = np.loadtxt(BytesIO(databuffer), dtype=ARCHIVE_DTYPE)
+        data = Table.read(GENEVA_URL, format='ascii', header_start=19)
+        data = data.as_array()
         np.save(archive_file, data)
     else:
         data = np.load(archive_file)

--- a/astroML/datasets/LINEAR_sample.py
+++ b/astroML/datasets/LINEAR_sample.py
@@ -119,7 +119,7 @@ def fetch_LINEAR_sample(data_home=None, download_if_missing=True):
     ----------
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all astroML data is stored in '~/astroML_data'.
 
     download_if_missing : optional, default=True
         If False, raise a IOError if the data is not locally available
@@ -165,7 +165,7 @@ def fetch_LINEAR_geneva(data_home=None, download_if_missing=True):
     ----------
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all astroML data is stored in '~/astroML_data'.
 
     download_if_missing : optional, default=True
         If False, raise a IOError if the data is not locally available

--- a/astroML/datasets/dr7_quasar.py
+++ b/astroML/datasets/dr7_quasar.py
@@ -58,7 +58,7 @@ def fetch_dr7_quasar(data_home=None, download_if_missing=True):
     ----------
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all astroML data is stored in '~/astroML_data'.
 
     download_if_missing : optional, default=True
         If False, raise a IOError if the data is not locally available

--- a/astroML/datasets/imaging_sample.py
+++ b/astroML/datasets/imaging_sample.py
@@ -3,14 +3,13 @@ from __future__ import print_function, division
 import os
 
 import numpy as np
+from astropy.table import Table
 
 from . import get_data_home
-from .tools import download_with_progress_bar
 
-DATA_URL = ("http://www.astro.washington.edu/users/"
-            "ivezic/DMbook/data/imagingSample_20sqdeg.fit")
-DATA_URL = ("http://www.astro.washington.edu/users/"
-            "ivezic/DMbook/data/sgSDSSimagingSample.fit")
+
+DATA_URL = ("https://github.com/astroML/astroML-data/raw/master/datasets/"
+            "sgSDSSimagingSample.fit.gz")
 
 
 def fetch_imaging_sample(data_home=None, download_if_missing=True):
@@ -92,9 +91,6 @@ def fetch_imaging_sample(data_home=None, download_if_missing=True):
           p.modelMag_r < 22.5
         --- the end of query
     """
-    # fits is an optional dependency: don't import globally
-    from astropy.io import fits
-
     data_home = get_data_home(data_home)
 
     archive_file = os.path.join(data_home, os.path.basename(DATA_URL))
@@ -104,8 +100,9 @@ def fetch_imaging_sample(data_home=None, download_if_missing=True):
             raise IOError('data not present on disk. '
                           'set download_if_missing=True to download')
 
-        fitsdata = download_with_progress_bar(DATA_URL)
-        open(archive_file, 'wb').write(fitsdata)
+        data = Table.read(DATA_URL)
+        data.write(archive_file)
+    else:
+        data = Table.read(archive_file)
 
-    hdulist = fits.open(archive_file)
-    return np.asarray(hdulist[1].data)
+    return np.asarray(data)

--- a/astroML/datasets/imaging_sample.py
+++ b/astroML/datasets/imaging_sample.py
@@ -19,7 +19,7 @@ def fetch_imaging_sample(data_home=None, download_if_missing=True):
     ----------
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all astroML data is stored in '~/astroML_data'.
 
     download_if_missing : optional, default=True
         If False, raise a IOError if the data is not locally available

--- a/astroML/datasets/moving_objects.py
+++ b/astroML/datasets/moving_objects.py
@@ -8,7 +8,8 @@ from .tools import download_with_progress_bar
 from ..py3k_compat import BytesIO
 from . import get_data_home
 
-DATA_URL = 'http://www.astro.washington.edu/users/ivezic/sdssmoc/ADR3.dat.gz'
+DATA_URL = ('https://github.com/astroML/astroML-data/raw/master/datasets/'
+            'ADR3.dat.gz')
 
 ARCHIVE_FILE = 'moving_objects.npy'
 

--- a/astroML/datasets/moving_objects.py
+++ b/astroML/datasets/moving_objects.py
@@ -83,7 +83,7 @@ def fetch_moving_objects(data_home=None, download_if_missing=True,
     ----------
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all astroML data is stored in '~/astroML_data'.
 
     download_if_missing : optional, default=True
         If False, raise a IOError if the data is not locally available

--- a/astroML/datasets/nasa_atlas.py
+++ b/astroML/datasets/nasa_atlas.py
@@ -32,7 +32,7 @@ def fetch_nasa_atlas(data_home=None,
     ----------
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all astroML data is stored in '~/astroML_data'.
 
     download_if_missing : optional, default=True
         If False, raise a IOError if the data is not locally available

--- a/astroML/datasets/nasa_atlas.py
+++ b/astroML/datasets/nasa_atlas.py
@@ -18,8 +18,8 @@ from .tools import download_with_progress_bar
 from . import get_data_home
 
 
-DATA_URL = ('http://www.astro.washington.edu/users/ivezic/'
-            'DMbook/nsa_v0_1_2_reduced.npy')
+DATA_URL = ('https://github.com/astroML/astroML-data/raw/master/datasets/'
+            'nsa_v0_1_2_reduced.npy')
 
 ARCHIVE_FILE = os.path.basename(DATA_URL)
 

--- a/astroML/datasets/rrlyrae_mags.py
+++ b/astroML/datasets/rrlyrae_mags.py
@@ -8,8 +8,8 @@ from . import get_data_home
 from . import fetch_sdss_S82standards
 from .tools import download_with_progress_bar
 
-DATA_URL = ("http://www.astro.washington.edu/users/"
-            "ivezic/DMbook/data/RRLyrae.fit")
+DATA_URL = ("https://github.com/astroML/astroML-data/raw/master/datasets/"
+            "RRLyrae.fit")
 
 
 def fetch_rrlyrae_mags(data_home=None, download_if_missing=True):

--- a/astroML/datasets/rrlyrae_mags.py
+++ b/astroML/datasets/rrlyrae_mags.py
@@ -19,7 +19,7 @@ def fetch_rrlyrae_mags(data_home=None, download_if_missing=True):
     ----------
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all astroML data is stored in '~/astroML_data'.
 
     download_if_missing : optional, default=True
         If False, raise a IOError if the data is not locally available
@@ -71,7 +71,7 @@ def fetch_rrlyrae_combined(data_home=None, download_if_missing=True):
     ----------
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all astroML data is stored in '~/astroML_data'.
 
     download_if_missing : optional, default=True
         If False, raise a IOError if the data is not locally available

--- a/astroML/datasets/rrlyrae_templates.py
+++ b/astroML/datasets/rrlyrae_templates.py
@@ -19,7 +19,7 @@ def fetch_rrlyrae_templates(data_home=None, download_if_missing=True):
     ----------
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all astroML data is stored in '~/astroML_data'.
 
     download_if_missing : optional, default=True
         If False, raise a IOError if the data is not locally available

--- a/astroML/datasets/sdss_S82standards.py
+++ b/astroML/datasets/sdss_S82standards.py
@@ -51,7 +51,7 @@ def fetch_sdss_S82standards(data_home=None, download_if_missing=True,
     ----------
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all astroML data is stored in '~/astroML_data'.
 
     download_if_missing : bool, optional, default=True
         If False, raise a IOError if the data is not locally available

--- a/astroML/datasets/sdss_S82standards.py
+++ b/astroML/datasets/sdss_S82standards.py
@@ -9,10 +9,10 @@ from .tools import download_with_progress_bar
 from ..py3k_compat import BytesIO
 from . import get_data_home
 
-DATA_URL = ('http://www.astro.washington.edu/users/ivezic/'
-            'sdss/catalogs/stripe82calibStars_v2.6.dat.gz')
-DATA_URL_2MASS = ('http://www.astro.washington.edu/users/ivezic/'
-                  'sdss/catalogs/stripe82calibStars_2MASS_v2.6.dat.gz')
+DATA_URL = ('https://github.com/astroML/astroML-data/raw/master/datasets/'
+            'stripe82calibStars_v2.6.dat.gz')
+DATA_URL_2MASS = ('https://github.com/astroML/astroML-data/raw/master/datasets/'
+                  'stripe82calibStars_2MASS_v2.6.dat.gz')
 
 ARCHIVE_FILE = 'sdss_S82standards.npy'
 ARCHIVE_FILE_2MASS = 'sdss_S82standards_2mass.npy'

--- a/astroML/datasets/sdss_corrected_spectra.py
+++ b/astroML/datasets/sdss_corrected_spectra.py
@@ -71,7 +71,7 @@ def fetch_sdss_corrected_spectra(data_home=None,
     ----------
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all astroML data is stored in '~/astroML_data'.
 
     download_if_missing : optional, default=True
         If False, raise a IOError if the data is not locally available

--- a/astroML/datasets/sdss_filters.py
+++ b/astroML/datasets/sdss_filters.py
@@ -22,7 +22,7 @@ def fetch_sdss_filter(fname, data_home=None, download_if_missing=True):
         filter name: must be one of 'ugriz'
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all data is stored in '~/astroML_data'.
 
     download_if_missing : optional, default=True
         If False, raise a IOError if the data is not locally available
@@ -69,7 +69,7 @@ def fetch_vega_spectrum(data_home=None, download_if_missing=True):
         filter name: must be one of 'ugriz'
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all astroML data is stored in '~/astroML_data'.
 
     download_if_missing : optional, default=True
         If False, raise a IOError if the data is not locally available

--- a/astroML/datasets/sdss_filters.py
+++ b/astroML/datasets/sdss_filters.py
@@ -8,7 +8,8 @@ from astroML.datasets import get_data_home
 from ..py3k_compat import urlopen
 
 # Info on vega spectrum: http://www.stsci.edu/hst/observatory/cdbs/calspec.html
-VEGA_URL = 'http://www.astro.washington.edu/users/ivezic/DMbook/data/1732526_nic_002.ascii'
+VEGA_URL = ('https://github.com/astroML/astroML-data/raw/master/datasets/'
+            '1732526_nic_002.ascii')
 FILTER_URL = 'http://classic.sdss.org/dr7/instruments/imager/filters/%s.dat'
 
 

--- a/astroML/datasets/sdss_galaxy_colors.py
+++ b/astroML/datasets/sdss_galaxy_colors.py
@@ -25,7 +25,7 @@ def fetch_sdss_galaxy_colors(data_home=None, download_if_missing=True):
     ----------
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all astroML data is stored in '~/astroML_data'.
 
     download_if_missing : optional, default=True
         If False, raise a IOError if the data is not locally available

--- a/astroML/datasets/sdss_spectrum.py
+++ b/astroML/datasets/sdss_spectrum.py
@@ -24,11 +24,11 @@ def fetch_sdss_spectrum(plate, mjd, fiber, data_home=None,
     ----------------
     data_home: string (optional)
         directory in which to cache downloaded fits files.  If not
-        specified, it will be set to ~/astroML_data
+        specified, it will be set to ~/astroML_data.
     download_if_missing: boolean (default = True)
-        download the fits file if it is not cached locally
+        download the fits file if it is not cached locally.
     cache_to_disk: boolean (default = True)
-        cache downloaded file to data_home
+        cache downloaded file to data_home.
 
     Returns
     -------

--- a/astroML/datasets/sdss_sspp.py
+++ b/astroML/datasets/sdss_sspp.py
@@ -57,7 +57,7 @@ def fetch_sdss_sspp(data_home=None, download_if_missing=True, cleaned=False):
     ----------
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
+        all astroML data is stored in '~/astroML_data'.
 
     download_if_missing : bool (optional) default=True
         If False, raise a IOError if the data is not locally available

--- a/astroML/datasets/sdss_sspp.py
+++ b/astroML/datasets/sdss_sspp.py
@@ -3,12 +3,13 @@ from __future__ import print_function
 import os
 
 import numpy as np
+from astropy.table import Table
 
 from . import get_data_home
-from .tools import download_with_progress_bar
 
-DATA_URL = ("http://www.astro.washington.edu/users/ivezic/"
-            "DMbook/data/SDSSssppDR9_rerun122.fit")
+
+DATA_URL = ("https://github.com/astroML/astroML-data/raw/master/datasets/"
+            "SDSSssppDR9_rerun122.fit.gz")
 
 
 def compute_distances(data):
@@ -106,9 +107,6 @@ def fetch_sdss_sspp(data_home=None, download_if_missing=True, cleaned=False):
     >>> print(data['dec'][:1])  # first DEC value
     [-1.04175591]
     """
-    # fits is an optional dependency: don't import globally
-    from astropy.io import fits
-
     data_home = get_data_home(data_home)
 
     archive_file = os.path.join(data_home, os.path.basename(DATA_URL))
@@ -118,12 +116,10 @@ def fetch_sdss_sspp(data_home=None, download_if_missing=True, cleaned=False):
             raise IOError('data not present on disk. '
                           'set download_if_missing=True to download')
 
-        fitsdata = download_with_progress_bar(DATA_URL)
-        open(archive_file, 'wb').write(fitsdata)
-
-    hdulist = fits.open(archive_file)
-
-    data = np.asarray(hdulist[1].data)
+        data = Table.read(DATA_URL)
+        data.write(archive_file)
+    else:
+        data = Table.read(archive_file)
 
     if cleaned:
         # -1.1 < FeH < 0.1
@@ -150,4 +146,4 @@ def fetch_sdss_sspp(data_home=None, download_if_missing=True, cleaned=False):
         # abs(radVel) < 100 km/s
         data = data[(abs(data['radVel']) < 100)]
 
-    return data
+    return np.asarray(data)

--- a/astroML/datasets/wmap_temperatures.py
+++ b/astroML/datasets/wmap_temperatures.py
@@ -21,8 +21,7 @@ def fetch_wmap_temperatures(masked=False, data_home=None,
         If False, then return the raw temperature array
     data_home : optional, default=None
         Specify another download and cache folder for the datasets. By default
-        all scikit learn data is stored in '~/astroML_data' subfolders.
-
+        all astroML data is stored in '~/astroML_data'.
     download_if_missing : optional, default=True
         If False, raise a IOError if the data is not locally available
         instead of trying to download the data from the source site.


### PR DESCRIPTION
This fixes #179 

This PR starts to move the fetchers more towards astropy, e.g. using Table to read in a remote URL, etc.
However on the user side everything is still transparent, as the functions still return numpy arrays. 