### PR TITLE
Fix rc syntax for mpl 3.1

### DIFF
--- a/astroML/plotting/settings.py
+++ b/astroML/plotting/settings.py
@@ -19,7 +19,7 @@ def setup_text_plots(fontsize=8, usetex=True):
         matplotlib.rc('_internal', classic_mode=True)
     else:
         # New in mpl 3.1
-        matplotlib.rc('scatter.edgecolors', 'b')
+        matplotlib.rc('scatter', edgecolors='b')
     matplotlib.rc('grid', linestyle=':')
     matplotlib.rc('errorbar', capsize=3)
     matplotlib.rc('image', cmap='viridis')


### PR DESCRIPTION
The bug is resurfaced now that the release candidate for mpl 3.1 is out.