### PR TITLE
Cleaning up sklearn <0.14 workaround

### DIFF
--- a/astroML/datasets/tools/cas_query.py
+++ b/astroML/datasets/tools/cas_query.py
@@ -76,7 +76,6 @@ def query_plate_mjd_fiber(n_spectra,
         try:
             res[i] = line.decode().strip().split(',')
         except BaseException:
-            assert 0
             raise ValueError(b'\n'.join(output))
 
     ntot = i + 1


### PR DESCRIPTION
The minimum required version is 0.18 in 0.4, so the workaround can be removed.