### PR TITLE
Deprecate savitzky_golay

### DIFF
--- a/astroML/filters.py
+++ b/astroML/filters.py
@@ -1,10 +1,14 @@
 import numpy as np
 from scipy import optimize, fftpack, signal
 
+from astroML.utils.decorators import deprecated
+from astroML.utils.exceptions import AstroMLDeprecationWarning
 
 # Note: there is a scipy PR to include an improved SG filter within the
 # scipy.signal submodule.  It should replace this when it's finished.
 # see http://github.com/scipy/scipy/pull/304
+@deprecated('1.0', alternative='scipy.signal.savgol_filter',
+            warning_type=AstroMLDeprecationWarning)
 def savitzky_golay(y, window_size, order, deriv=0,
                    use_fft=True):
     r"""Smooth (and optionally differentiate) data with a Savitzky-Golay filter

--- a/astroML/tests/test_filters.py
+++ b/astroML/tests/test_filters.py
@@ -1,12 +1,16 @@
+import pytest
+
 import numpy as np
 from numpy.testing import assert_allclose
 from astroML.filters import savitzky_golay, wiener_filter
+from astroML.utils.exceptions import AstroMLDeprecationWarning
 
 
 def test_savitzky_golay():
     y = np.zeros(100)
     y[::2] = 1
-    f = savitzky_golay(y, window_size=3, order=1)
+    with pytest.warns(AstroMLDeprecationWarning):
+        f = savitzky_golay(y, window_size=3, order=1)
     assert_allclose(f, (2 - y) / 3.)
 
 
@@ -15,8 +19,9 @@ def test_savitzky_golay_fft():
 
     for width in [3, 5]:
         for order in range(width - 1):
-            f1 = savitzky_golay(y, width, order, use_fft=False)
-            f2 = savitzky_golay(y, width, order, use_fft=True)
+            with pytest.warns(AstroMLDeprecationWarning):
+                f1 = savitzky_golay(y, width, order, use_fft=False)
+                f2 = savitzky_golay(y, width, order, use_fft=True)
             assert_allclose(f1, f2)
 
 

--- a/doc/user_guide/installation.rst
+++ b/doc/user_guide/installation.rst
@@ -110,7 +110,7 @@ The core ``astroML`` package requires the following:
 
 - `Python <http://python.org>`_ version 3.5+
 - `Numpy <http://numpy.scipy.org/>`_ >= 1.4
-- `Scipy <http://www.scipy.org/>`_ >= 0.11
+- `Scipy <http://www.scipy.org/>`_ >= 0.14
 - `scikit-learn <http://scikit-learn.org/>`_ >= 0.18
 - `matplotlib <http://matplotlib.org/>`_ >= 0.99
 - `astropy <http://www.astropy.org/>`_ >= 1.1


### PR DESCRIPTION
Adhering to the TODO comment in the source code, we shall remove this function and promote the usage of the scipy equivalent instead.