### PR TITLE
Mark dataset examples as remote data

### DIFF
--- a/astroML/datasets/LIGO_bigdog.py
+++ b/astroML/datasets/LIGO_bigdog.py
@@ -85,12 +85,12 @@ def fetch_LIGO_bigdog(data_home=None, download_if_missing=True):
     Examples
     --------
     >>> from astroML.datasets import fetch_LIGO_bigdog
-    >>> data = fetch_LIGO_bigdog()  # doctest: +IGNORE_OUTPUT
-    >>> print(data.dtype.names)
+    >>> data = fetch_LIGO_bigdog()  # doctest: +IGNORE_OUTPUT +REMOTE_DATA
+    >>> print(data.dtype.names)  # doctest: +REMOTE_DATA
     ('t', 'Hanford', 'Livingston', 'Virgo')
-    >>> print(data['t'][:3])
+    >>> print(data['t'][:3])  # doctest: +REMOTE_DATA
     [  0.00000000e+00   6.10400000e-05   1.22070000e-04]
-    >>> print(data['Hanford'][:3])
+    >>> print(data['Hanford'][:3])  # doctest: +REMOTE_DATA
     [  1.26329846e-17   1.26846778e-17   1.19187381e-17]
     """
     data_home = get_data_home(data_home)

--- a/astroML/datasets/LINEAR_sample.py
+++ b/astroML/datasets/LINEAR_sample.py
@@ -33,8 +33,8 @@ class LINEARdata:
 
     Example
     -------
-    >>> data = fetch_LINEAR_sample()  # doctest: +IGNORE_OUTPUT
-    >>> lightcurve = data[data.ids[0]]
+    >>> data = fetch_LINEAR_sample()  # doctest: +IGNORE_OUTPUT +REMOTE_DATA
+    >>> lightcurve = data[data.ids[0]]  # doctest: +REMOTE_DATA
     """
     @staticmethod
     def _name_to_id(name):

--- a/astroML/datasets/dr7_quasar.py
+++ b/astroML/datasets/dr7_quasar.py
@@ -70,9 +70,9 @@ def fetch_dr7_quasar(data_home=None, download_if_missing=True):
     Examples
     --------
     >>> from astroML.datasets import fetch_dr7_quasar
-    >>> data = fetch_dr7_quasar()  # doctest: +IGNORE_OUTPUT
-    >>> u_g = data['mag_u'] - data['mag_g']
-    >>> u_g[:3]  # first three u-g colors
+    >>> data = fetch_dr7_quasar()  # doctest: +IGNORE_OUTPUT +REMOTE_DATA
+    >>> u_g = data['mag_u'] - data['mag_g']  # doctest: +REMOTE_DATA
+    >>> u_g[:3]  # first three u-g colors  # doctest: +REMOTE_DATA
     array([-0.07699966,  0.03600121,  0.10900116], dtype=float32)
 
     Notes

--- a/astroML/datasets/imaging_sample.py
+++ b/astroML/datasets/imaging_sample.py
@@ -31,14 +31,16 @@ def fetch_imaging_sample(data_home=None, download_if_missing=True):
     Examples
     --------
     >>> from astroML.datasets import fetch_imaging_sample
-    >>> data = fetch_imaging_sample()  # doctest: +IGNORE_OUTPUT
-    >>> data.shape  # number of objects in dataset
+    >>> data = fetch_imaging_sample()  # doctest: +IGNORE_OUTPUT +REMOTE_DATA
+    >>> # number of objects in dataset
+    >>> data.shape  # doctest: +REMOTE_DATA
     (330753,)
-    >>> print(data.dtype.names[:5])  # names of the first five columns
+    >>> # names of the first five columns
+    >>> print(data.dtype.names[:5])  # doctest: +REMOTE_DATA
     ('ra', 'dec', 'run', 'rExtSFD', 'uRaw')
-    >>> print(data['ra'][:2])
+    >>> print(data['ra'][:2])  # doctest: +REMOTE_DATA
     [0.358174 0.358382]
-    >>> print(data['dec'][:2])
+    >>> print(data['dec'][:2])  # doctest: +REMOTE_DATA
     [-0.508718 -0.551157]
 
     Notes

--- a/astroML/datasets/moving_objects.py
+++ b/astroML/datasets/moving_objects.py
@@ -105,11 +105,13 @@ def fetch_moving_objects(data_home=None, download_if_missing=True,
     Examples
     --------
     >>> from astroML.datasets import fetch_moving_objects
-    >>> data = fetch_moving_objects()  # doctest: +IGNORE_OUTPUT
-    >>> print(len(data))  # number of objects
+    >>> data = fetch_moving_objects()  # doctest: +IGNORE_OUTPUT +REMOTE_DATA
+    >>> # number of objects
+    >>> print(len(data))  # doctest: +REMOTE_DATA
     43424
-    >>> u_g = data['mag_u'] - data['mag_g']
-    >>> print(u_g[:5])  # first five u-g colors of the dataset
+    >>> # first five u-g colors of the dataset
+    >>> u_g = data['mag_u'] - data['mag_g']  # doctest: +REMOTE_DATA
+    >>> print(u_g[:5])  # doctest: +REMOTE_DATA
     [1.4899998 1.7800007 1.6500015 2.0100002 1.8199997]
     """
     data_home = get_data_home(data_home)

--- a/astroML/datasets/rrlyrae_mags.py
+++ b/astroML/datasets/rrlyrae_mags.py
@@ -31,8 +31,9 @@ def fetch_rrlyrae_mags(data_home=None, download_if_missing=True):
     Examples
     --------
     >>> from astroML.datasets import fetch_rrlyrae_mags
-    >>> data = fetch_rrlyrae_mags()  # doctest: +IGNORE_OUTPUT
-    >>> data.shape  # number of objects in dataset
+    >>> data = fetch_rrlyrae_mags()  # doctest: +IGNORE_OUTPUT +REMOTE_DATA
+    >>> # number of objects in dataset
+    >>> data.shape  # doctest: +REMOTE_DATA
     (483,)
 
     Notes

--- a/astroML/datasets/sdss_S82standards.py
+++ b/astroML/datasets/sdss_S82standards.py
@@ -101,9 +101,9 @@ def fetch_sdss_S82standards(data_home=None, download_if_missing=True,
 
     Examples
     --------
-    >>> data = fetch_sdss_S82standards()  # doctest: +IGNORE_OUTPUT
-    >>> u_g = data['mmed_u'] - data['mmed_g']
-    >>> print(u_g[:4])
+    >>> data = fetch_sdss_S82standards()  # doctest: +IGNORE_OUTPUT +REMOTE_DATA
+    >>> u_g = data['mmed_u'] - data['mmed_g']  # doctest: +REMOTE_DATA
+    >>> print(u_g[:4])  # doctest: +REMOTE_DATA
     [-22.23500061   1.34900093   1.43799973   2.08200073]
 
     References

--- a/astroML/datasets/sdss_specgals.py
+++ b/astroML/datasets/sdss_specgals.py
@@ -75,14 +75,18 @@ def fetch_sdss_specgals(data_home=None, download_if_missing=True):
     Examples
     --------
     >>> from astroML.datasets import fetch_sdss_specgals
-    >>> data = fetch_sdss_specgals()  # doctest: +IGNORE_OUTPUT
-    >>> data.shape  # number of objects in dataset
+    >>> data = fetch_sdss_specgals()  # doctest: +IGNORE_OUTPUT +REMOTE_DATA
+    >>> # number of objects in dataset
+    >>> data.shape  # doctest: +REMOTE_DATA
     (661598,)
-    >>> data.dtype.names[:5]  # first five column names
+    >>> # first five column names
+    >>> data.dtype.names[:5]  # doctest: +REMOTE_DATA
     ('ra', 'dec', 'mjd', 'plate', 'fiberID')
-    >>> print(data['ra'][:3])  # first three RA values
+    >>> # first three RA values
+    >>> print(data['ra'][:3])  # doctest: +REMOTE_DATA
     [ 146.71419105  146.74414186  146.62857334]
-    >>> print(data['dec'][:3])  #  first three declination values
+    >>> # first three declination values
+    >>> print(data['dec'][:3])  # doctest: +REMOTE_DATA
     [-1.04127639 -0.6522198  -0.7651468 ]
     """
 

--- a/astroML/datasets/sdss_sspp.py
+++ b/astroML/datasets/sdss_sspp.py
@@ -95,14 +95,18 @@ def fetch_sdss_sspp(data_home=None, download_if_missing=True, cleaned=False):
     Examples
     --------
     >>> from astroML.datasets import fetch_sdss_sspp
-    >>> data = fetch_sdss_sspp()  # doctest: +IGNORE_OUTPUT
-    >>> data.shape  # number of objects in dataset
+    >>> data = fetch_sdss_sspp()  # doctest: +IGNORE_OUTPUT +REMOTE_DATA
+    >>> # number of objects in dataset
+    >>> data.shape  # doctest: +REMOTE_DATA
     (327260,)
-    >>> print(data.dtype.names[:5])  # names of the first five columns
+    >>> # names of the first five columns
+    >>> print(data.dtype.names[:5])  # doctest: +REMOTE_DATA
     ('ra', 'dec', 'Ar', 'upsf', 'uErr')
-    >>> print(data['ra'][:1])  # first RA value
+    >>> # first RA value
+    >>> print(data['ra'][:1])  # doctest: +REMOTE_DATA
     [49.6275024]
-    >>> print(data['dec'][:1])  # first DEC value
+    >>> # first DEC value
+    >>> print(data['dec'][:1])  # doctest: +REMOTE_DATA
     [-1.04175591]
     """
     data_home = get_data_home(data_home)


### PR DESCRIPTION
These datasets require a download and therefore should be marked with `+REMOTE_DATA`. This caused a failure during the Debian build.

I removed the original comment here since they seem obvious to me (and I was not sure how to combine them with the doctest option ;-) ).