### PR TITLE
Opting in raising deprecations as exceptions

### DIFF
--- a/astroML/conftest.py
+++ b/astroML/conftest.py
@@ -9,6 +9,11 @@ except ImportError:
                                               PYTEST_HEADER_MODULES,
                                               TESTED_VERSIONS)
 
+from astropy.tests.helper import enable_deprecations_as_exceptions
+
+
+enable_deprecations_as_exceptions()
+
 try:
     PYTEST_HEADER_MODULES['Cython'] = 'Cython'
     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'


### PR DESCRIPTION
This should work, yet it doesn't that puzzles me. Locally I see several deprecations, some  are coming from the package itself, so not raising those is OK, but there are others coming directly from numpy, yet the overall status is passing with warnings:

E.g. 
```
 astroML/density_estimation/tests/test_density.py::test_gaussian1d
  <string>:6: DeprecationWarning: object of type <class 'float'> cannot be safely interpreted as an integer.
```