### PR TITLE
Fix compatibility with recently released upstream libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,16 @@ matrix:
         - env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.13
 
         - env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.12 ASTROPY_VERSION=3.0 PIP_DEPENDENCIES='scipy==1.0.* scikit-learn matplotlib pytest-astropy'
-               CONDA_DEPENDENCIES=''
+               CONDA_DEPENDENCIES='' PYTEST_VERSION=">4"
 
         - env: PYTHON_VERSION=3.6 SCRIPT_CMD='make -C doc html' PIP_DEPENDENCIES='sphinx'
 
         - env: PYTHON_VERSION=3.8 PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
                CONDA_DEPENDENCIES=""
+
+   allow_failures:
+        - env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.12 ASTROPY_VERSION=3.0 PIP_DEPENDENCIES='scipy==1.0.* scikit-learn matplotlib pytest-astropy'
+               CONDA_DEPENDENCIES='' PYTEST_VERSION=">4"
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     global:
         - PYTHON_VERSION=3.7
         - ASTROPY_VERSION=stable
-        - NUMPY_VERSION=stable
+        - NUMPY_VERSION=1.18
         - CONDA_DEPENDENCIES='scipy scikit-learn matplotlib'
         - PIP_DEPENDENCIES='pytest-doctestplus>=0.3 pytest-remotedata pytest-astropy-header'
         - DEBUG=True
@@ -35,7 +35,8 @@ matrix:
 
         - env: PYTHON_VERSION=3.6 SCRIPT_CMD='make -C doc html' PIP_DEPENDENCIES='sphinx'
 
-        - env: PYTHON_VERSION=3.8
+        - env: PYTHON_VERSION=3.8 PIP_DEPENDENCIES="scipy scikit-learn matplotlib pytest-astropy"
+               CONDA_DEPENDENCIES=""
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
         - NUMPY_VERSION=1.18
         - CONDA_DEPENDENCIES='scipy scikit-learn matplotlib'
         - PIP_DEPENDENCIES='pytest-doctestplus>=0.3 pytest-remotedata pytest-astropy-header'
+        - PIP_ALL_DEPENDENCIES='scipy scikit-learn matplotlib pytest-astropy'
         - DEBUG=True
         - SCRIPT_CMD='pytest astroML'
 
@@ -31,11 +32,12 @@ matrix:
 
         - env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.13
 
-        - env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.12 ASTROPY_VERSION=3.0
+        - env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.12 ASTROPY_VERSION=3.0 PIP_DEPENDENCIES='scipy==1.0.* scikit-learn matplotlib pytest-astropy'
+               CONDA_DEPENDENCIES=''
 
         - env: PYTHON_VERSION=3.6 SCRIPT_CMD='make -C doc html' PIP_DEPENDENCIES='sphinx'
 
-        - env: PYTHON_VERSION=3.8 PIP_DEPENDENCIES="scipy scikit-learn matplotlib pytest-astropy"
+        - env: PYTHON_VERSION=3.8 PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
                CONDA_DEPENDENCIES=""
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os: linux
 addons:
     apt:
         packages:
-            - gfortran
             - texlive-latex-extra
             - dvipng
             - texlive-fonts-recommended
@@ -16,18 +15,17 @@ env:
         - ASTROPY_VERSION=stable
         - NUMPY_VERSION=stable
         - CONDA_DEPENDENCIES='scipy scikit-learn matplotlib'
-        - PIP_DEPENDENCIES='pytest-doctestplus>=0.3 pytest-remotedata'
+        - PIP_DEPENDENCIES='pytest-doctestplus>=0.3 pytest-remotedata pytest-astropy-header'
         - DEBUG=True
-        - PYTEST_VERSION='<4'
         - SCRIPT_CMD='pytest astroML'
 
 matrix:
     fast_finish: true
 
     include:
-        - env: NUMPY_VERSION=1.16 SCRIPT_CMD='pytest astroML --remote-data'
+        - env: NUMPY_VERSION=1.17 SCRIPT_CMD='pytest astroML --remote-data'
 
-        - env: NUMPY_VERSION=1.15
+        - env: NUMPY_VERSION=1.16
 
         - env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.14
 
@@ -36,6 +34,8 @@ matrix:
         - env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.12 ASTROPY_VERSION=3.0
 
         - env: PYTHON_VERSION=3.6 SCRIPT_CMD='make -C doc html' PIP_DEPENDENCIES='sphinx'
+
+        - env: PYTHON_VERSION=3.8
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/astroML/classification/gmm_bayes.py
+++ b/astroML/classification/gmm_bayes.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from sklearn.naive_bayes import BaseNB
 from sklearn.mixture import GaussianMixture
+from sklearn.utils import check_array
 
 
 class GMMBayes(BaseNB):
@@ -34,7 +35,7 @@ class GMMBayes(BaseNB):
         self.kwargs = kwargs
 
     def fit(self, X, y):
-        X = np.asarray(X)
+        X = self._check_X(X)
         y = np.asarray(y)
 
         n_samples, n_features = X.shape
@@ -74,3 +75,6 @@ class GMMBayes(BaseNB):
         X = np.asarray(np.atleast_2d(X))
         logprobs = np.array([g.score_samples(X) for g in self.gmms_]).T
         return logprobs + np.log(self.class_prior_)
+
+    def _check_X(self, X):
+        return check_array(X)

--- a/astroML/conftest.py
+++ b/astroML/conftest.py
@@ -1,13 +1,10 @@
+from pytest_astropy_header.display import (PYTEST_HEADER_MODULES,
+                                           TESTED_VERSIONS)
 
-try:
-    from astropy.tests.plugins.display import (pytest_report_header,
-                                               PYTEST_HEADER_MODULES,
-                                               TESTED_VERSIONS)
-except ImportError:
-    # When using astropy 2.0
-    from astropy.tests.pytest_plugins import (pytest_report_header,
-                                              PYTEST_HEADER_MODULES,
-                                              TESTED_VERSIONS)
+
+def pytest_configure(config):
+    config.option.astropy_header = True
+
 
 try:
     PYTEST_HEADER_MODULES['Cython'] = 'Cython'

--- a/astroML/conftest.py
+++ b/astroML/conftest.py
@@ -1,28 +1,28 @@
-from pytest_astropy_header.display import (PYTEST_HEADER_MODULES,
-                                           TESTED_VERSIONS)
-
-
-def pytest_configure(config):
-    config.option.astropy_header = True
-
-
 try:
-    PYTEST_HEADER_MODULES['Cython'] = 'Cython'
-    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
-    PYTEST_HEADER_MODULES['scikit-learn'] = 'sklearn'
-    # pymc import here triggers pytest INTERNALERROR thus as a temporary
-    # measure we don't list its version number
-    #    PYTEST_HEADER_MODULES['pymc'] = 'pymc'
-    PYTEST_HEADER_MODULES['astroML_addons'] = 'astroML_addons'
-    del PYTEST_HEADER_MODULES['h5py']
-    del PYTEST_HEADER_MODULES['Pandas']
-except (KeyError):
+    from pytest_astropy_header.display import (PYTEST_HEADER_MODULES,
+                                               TESTED_VERSIONS)
+
+    def pytest_configure(config):
+        config.option.astropy_header = True
+    try:
+        PYTEST_HEADER_MODULES['Cython'] = 'Cython'
+        PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
+        PYTEST_HEADER_MODULES['scikit-learn'] = 'sklearn'
+        # pymc import here triggers pytest INTERNALERROR thus as a temporary
+        # measure we don't list its version number
+        #    PYTEST_HEADER_MODULES['pymc'] = 'pymc'
+        PYTEST_HEADER_MODULES['astroML_addons'] = 'astroML_addons'
+        del PYTEST_HEADER_MODULES['h5py']
+        del PYTEST_HEADER_MODULES['Pandas']
+    except (KeyError):
+        pass
+
+    # This is to figure out the package version, rather than
+    # using Astropy's
+
+    from . import __version__ as version
+
+    TESTED_VERSIONS['astroMl'] = version
+
+except ImportError:
     pass
-
-
-# This is to figure out the package version, rather than
-# using Astropy's
-
-from . import __version__ as version
-
-TESTED_VERSIONS['astroMl'] = version

--- a/astroML/density_estimation/tests/test_density.py
+++ b/astroML/density_estimation/tests/test_density.py
@@ -28,7 +28,7 @@ def test_1D_density(clf, atol=100):
 
 
 def test_gaussian1d():
-    x = np.linspace(-6, 10, 1E3)
+    x = np.linspace(-6, 10, 1000)
     means = np.array([-1.5, 0.0, 2.3])
     sigmas = np.array([1, 0.25, 3.8])
     weights = np.array([1, 1, 1])

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-addopts = --doctest-plus
-doctest_plus = enabled
-doctest_rst = True
-testspaths = astroML doc examples
-doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS FLOAT_CMP

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ doctest_plus = enabled
 doctest_rst = True
 testspaths = astroML doc examples
 doctest_optionflags = FLOAT_CMP ELLIPSIS NORMALIZE_WHITESPACE
+filterwarnings =
+    error::DeprecationWarning
+    error::FutureWarning

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,8 @@ setup(name=NAME,
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Scientific/Engineering :: Astronomy'],
      )


### PR DESCRIPTION
Changes is sklearn 0.22 affects functionality, the quick fix is in this PR for it. Longer term we need to move on from subclassing `BaseNB` as it got deprecated in 0.22

Minor fixes to make tests pass with astropy 4.0, numpy 1.18. 

