### PR TITLE
MNT: Set max-line-length for flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,6 @@ filterwarnings =
     error::DeprecationWarning
     error::FutureWarning
     ignore:Using or importing the ABCs from 'collections':DeprecationWarning
+
+[flake8]
+max-line-length = 100


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.