### PR TITLE
Add scatter contour error bars

### DIFF
--- a/astroML/plotting/scatter_contour.py
+++ b/astroML/plotting/scatter_contour.py
@@ -39,9 +39,10 @@ def scatter_contour(x, y,
         see doc string of pylab.contourf for more information
     filled_contour : bool
         If True (default) use filled contours. Otherwise, use contour outlines.
-    xerr, yerr : arrays
-        errors in x and and y dimensions. shape(N,) or shape(2, N); optional. From
-        matplotlib documentation (https://matplotlib.org/api/_as_gen/matplotlib.pyplot.errorbar.html):
+    xerr, yerr : arrays pr values (optional)
+        errors in x and and y dimensions. shape(N,) or shape(2, N). From
+        matplotlib documentation 
+        (https://matplotlib.org/api/_as_gen/matplotlib.pyplot.errorbar.html):
 
         "The errorbar sizes:
 
@@ -118,22 +119,36 @@ def scatter_contour(x, y,
 
     def coerce_error_array(arr):
         """
-        Ensures arrays are of the correct shape. Before being sent to hstack.
+        Ensures errorbar arrays are of the correct shape
 
+        Parameters
+        ----------
+        
+        arr : array or value
+            Errorbar object to be coerced into a form that can be passed 
+            to the hstack call.
+        
+        Returns
+        -------
+        coerced_arr : array
+            coerced arrays 
         """
         if not arr:  # if no errorbars are provided
-            arr = np.zeros(len(x))
+            coerced_arr = np.zeros(len(x))
 
         elif not np.shape(arr):   # if a scalar value has been provided
-            arr = arr * np.ones_like(x)
+            coerced_arr = arr * np.ones_like(x)
 
         elif np.shape(arr)[0] == 1:
-            arr = [arr, arr]
+            coerced_arr = [arr, arr]
 
         elif np.shape(arr)[0] > 2:
             raise ShapeError('Check shape of errorbars')
 
-        return arr
+        else:
+            coerced_arr = arr
+
+        return coerced_arr
 
 
     xerr, yerr = coerce_error_array(xerr), coerce_error_array(yerr)

--- a/astroML/plotting/scatter_contour.py
+++ b/astroML/plotting/scatter_contour.py
@@ -69,7 +69,7 @@ def scatter_contour(x, y,
 
     default_contour_args = dict(zorder=2)
     default_plot_args = dict(marker='.', linestyle='none', zorder=1,
-                            capsize=0)
+                             capsize=0)
 
     if plot_args is not None:
         default_plot_args.update(plot_args)
@@ -119,15 +119,14 @@ def scatter_contour(x, y,
         contours = ax.contour(H.T, levels, extent=extent, **contour_args)
 
     def coerce_error_array(arr):
-        """
-        Ensures errorbar arrays are of the correct shape
+        """Ensures errorbar arrays are of the correct shape
 
         Parameters
         ----------
         
         arr : array or value
-            Errorbar object to be coerced into a form that can be passed 
-            to the hstack call.
+            Errorbar object to be coerced into a form that 
+            can be passed to the hstack call.
         
         Returns
         -------
@@ -176,7 +175,7 @@ def scatter_contour(x, y,
     
     points = ax.errorbar(Xplot[:, 0], Xplot[:, 1], 
                          xerr=[Xplot[:, 2], Xplot[:, 3]], 
-                               yerr=[Xplot[:, 4], Xplot[:, 5]], 
-                               **plot_args)
+                         yerr=[Xplot[:, 4], Xplot[:, 5]], 
+                         **plot_args)
 
     return points, contours

--- a/astroML/plotting/scatter_contour.py
+++ b/astroML/plotting/scatter_contour.py
@@ -68,7 +68,8 @@ def scatter_contour(x, y,
     y = np.asarray(y)
 
     default_contour_args = dict(zorder=2)
-    default_plot_args = dict(marker='.', linestyle='none', zorder=1)
+    default_plot_args = dict(marker='.', linestyle='none', zorder=1,
+                            capsize=0)
 
     if plot_args is not None:
         default_plot_args.update(plot_args)

--- a/astroML/plotting/scatter_contour.py
+++ b/astroML/plotting/scatter_contour.py
@@ -64,6 +64,39 @@ def scatter_contour(x, y,
        points is the return value of ax.plot()
        contours is the return value of ax.contour or ax.contourf
     """
+
+    def coerce_error_array(arr):
+        """Ensures errorbar arrays are of the correct shape
+
+        Parameters
+        ----------
+        
+        arr : array or value
+            Errorbar object to be coerced into a form that 
+            can be passed to the hstack call.
+        
+        Returns
+        -------
+        coerced_arr : array
+            coerced array
+        """
+        if arr is None:  # if no errorbars are provided
+            coerced_arr = np.zeros((2, len(x)))
+
+        elif not np.shape(arr):   # if a scalar value has been provided
+            coerced_arr = arr * np.ones((2, len(x)))
+
+        elif len(np.shape(arr)) == 1:
+            coerced_arr = np.array([arr, arr])
+
+        elif np.shape(arr)[0] > 2 and len(np.shape(arr)) > 1:
+            raise ShapeError('Check shape of errorbars')
+
+        else:
+            coerced_arr = arr
+
+        return coerced_arr
+        
     x = np.asarray(x)
     y = np.asarray(y)
 
@@ -117,38 +150,6 @@ def scatter_contour(x, y,
         contours = ax.contourf(H.T, levels, extent=extent, **contour_args)
     else:
         contours = ax.contour(H.T, levels, extent=extent, **contour_args)
-
-    def coerce_error_array(arr):
-        """Ensures errorbar arrays are of the correct shape
-
-        Parameters
-        ----------
-        
-        arr : array or value
-            Errorbar object to be coerced into a form that 
-            can be passed to the hstack call.
-        
-        Returns
-        -------
-        coerced_arr : array
-            coerced array
-        """
-        if arr is None:  # if no errorbars are provided
-            coerced_arr = np.zeros((2, len(x)))
-
-        elif not np.shape(arr):   # if a scalar value has been provided
-            coerced_arr = arr * np.ones((2, len(x)))
-
-        elif len(np.shape(arr)) == 1:
-            coerced_arr = np.array([arr, arr])
-
-        elif np.shape(arr)[0] > 2 and len(np.shape(arr)) > 1:
-            raise ShapeError('Check shape of errorbars')
-
-        else:
-            coerced_arr = arr
-
-        return coerced_arr
 
 
     xerr, yerr = coerce_error_array(xerr), coerce_error_array(yerr)

--- a/astroML/plotting/scatter_contour.py
+++ b/astroML/plotting/scatter_contour.py
@@ -1,5 +1,8 @@
 import numpy as np
 
+class ShapeError(Error):
+    pass
+
 
 def scatter_contour(x, y,
                     levels=10,

--- a/astroML/plotting/scatter_contour.py
+++ b/astroML/plotting/scatter_contour.py
@@ -134,16 +134,16 @@ def scatter_contour(x, y,
         coerced_arr : array
             coerced array
         """
-        if not arr:  # if no errorbars are provided
+        if arr is None:  # if no errorbars are provided
             coerced_arr = np.zeros((2, len(x)))
 
         elif not np.shape(arr):   # if a scalar value has been provided
             coerced_arr = arr * np.ones((2, len(x)))
 
-        elif np.shape(arr)[0] == 1:
-            coerced_arr = [arr, arr]
+        elif len(np.shape(arr)):
+            coerced_arr = np.array([arr, arr])
 
-        elif np.shape(arr)[0] > 2:
+        elif np.shape(arr)[0] > 2 and len(np.shape(arr)) > 1:
             raise ShapeError('Check shape of errorbars')
 
         else:

--- a/astroML/plotting/scatter_contour.py
+++ b/astroML/plotting/scatter_contour.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-class ShapeError(Error):
+class ShapeError(ValueError):
     pass
 
 
@@ -131,13 +131,13 @@ def scatter_contour(x, y,
         Returns
         -------
         coerced_arr : array
-            coerced arrays 
+            coerced array
         """
         if not arr:  # if no errorbars are provided
-            coerced_arr = np.zeros(len(x))
+            coerced_arr = np.zeros((2, len(x)))
 
         elif not np.shape(arr):   # if a scalar value has been provided
-            coerced_arr = arr * np.ones_like(x)
+            coerced_arr = arr * np.ones((2, len(x)))
 
         elif np.shape(arr)[0] == 1:
             coerced_arr = [arr, arr]
@@ -172,9 +172,10 @@ def scatter_contour(x, y,
     else:
         Xplot = X
     
-        
+    
     points = ax.errorbar(Xplot[:, 0], Xplot[:, 1], 
                          xerr=[Xplot[:, 2], Xplot[:, 3]], 
-                               yerr=[Xplot[:, 4], Xplot[:, 4]], **plot_args)
+                               yerr=[Xplot[:, 4], Xplot[:, 5]], 
+                               **plot_args)
 
     return points, contours

--- a/astroML/plotting/scatter_contour.py
+++ b/astroML/plotting/scatter_contour.py
@@ -140,7 +140,7 @@ def scatter_contour(x, y,
         elif not np.shape(arr):   # if a scalar value has been provided
             coerced_arr = arr * np.ones((2, len(x)))
 
-        elif len(np.shape(arr)):
+        elif len(np.shape(arr)) == 1:
             coerced_arr = np.array([arr, arr])
 
         elif np.shape(arr)[0] > 2 and len(np.shape(arr)) > 1:


### PR DESCRIPTION
Follow-up on #222. I've added functionality for `scatter_contour` to handle error bars. This essentially amounts to changing the `ax.scatter` call to `ax.errorbar` and ensuring that user inputs (including `None` for `xerr` and/or `yerr`) are properly coerced and passed to the function call. I've tried to do this with minimal disruption to the organization of `scatter_contour` while replicating the direct function of `ax.errorbar`, but this definitely isn't the most parsimonious way to go about it.

Screen shots for each type of error bar input (as applied to SDSS Stripe 82 standard stars) are below. The only extra `plot_arg` that I've added for these figures is `ecolor='gray'`. Happy to add tests or further documentation!

![no_err](https://user-images.githubusercontent.com/35353555/88487251-3f93f200-cf38-11ea-87b8-b70976fd5252.jpg)
![only_x](https://user-images.githubusercontent.com/35353555/88487254-4589d300-cf38-11ea-83b0-3d464fe1c706.jpg)
![only_y](https://user-images.githubusercontent.com/35353555/88487255-4884c380-cf38-11ea-959b-c0040fb29544.jpg)
![symm_same_val](https://user-images.githubusercontent.com/35353555/88487257-4c184a80-cf38-11ea-9996-64b726a4cb9d.jpg)
![symm_diff_val](https://user-images.githubusercontent.com/35353555/88487260-4f133b00-cf38-11ea-8296-dc2bed57c769.jpg)
![asymm_varied_x](https://user-images.githubusercontent.com/35353555/88487261-533f5880-cf38-11ea-8c8e-0fd7402d0166.jpg)


