### PR TITLE
TST: Fixing doctestplus pytest incompatibility for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ env:
         - ASTROPY_VERSION=stable
         - NUMPY_VERSION=1.19
         - CONDA_DEPENDENCIES='scipy scikit-learn matplotlib'
-        - PIP_DEPENDENCIES='pytest-doctestplus>=0.3 pytest-remotedata pytest-astropy-header pymc3'
-        - PIP_ALL_DEPENDENCIES='scipy scikit-learn matplotlib pytest-astropy pymc3'
+        - PIP_DEPENDENCIES='pytest-doctestplus>=0.8 pytest-remotedata pytest-astropy-header pymc3'
+        - PIP_ALL_DEPENDENCIES='scipy scikit-learn matplotlib pytest-doctestplus>=0.8 pymc3'
         - DEBUG=True
         - SCRIPT_CMD='pytest astroML'
 


### PR DESCRIPTION
this is in fact an upstream issue, ci-helpers sets up the environment with some basic packages when astropy is installed, e.g. pytest-astropy. However the latest version of pytest-doctestplus (0.8.0), that is compatible with pytest 6.0 is not available on defaults, so the 0.7.0 is picked up that is causing the CI failures here. 

Adding this workaround until better upstream solution comes up.