### PR TITLE
Bring codebase closer to PEP-8 standards.

### DIFF
--- a/astroML/classification/tests/test_gmm_bayes.py
+++ b/astroML/classification/tests/test_gmm_bayes.py
@@ -2,7 +2,6 @@
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
-import warnings
 from astroML.classification import GMMBayes
 
 
@@ -60,7 +59,7 @@ def test_incompatible_number_of_components_exception():
         assert clf.fit(X, y)
 
     assert str(e.value) == ("n_components must be compatible with "
-                             "the number of classes")
+                            "the number of classes")
 
 
 def test_too_many_components_warning():

--- a/astroML/clustering/mst_clustering.py
+++ b/astroML/clustering/mst_clustering.py
@@ -147,9 +147,9 @@ class HierarchicalClustering(BaseEstimator):
             n_components = labels.max() + 1
 
         # eliminate links in T_trunc which are not clusters
-        I = sparse.eye(len(labels), len(labels))
-        I.data[0, labels < 0] = 0
-        T_trunc = I * T_trunc * I
+        Eye = sparse.eye(len(labels), len(labels))
+        Eye.data[0, labels < 0] = 0
+        T_trunc = Eye * T_trunc * Eye
 
         return n_components, labels, T_trunc
 

--- a/astroML/correlation.py
+++ b/astroML/correlation.py
@@ -102,7 +102,6 @@ def two_point(data, bins, method='standard',
         raise ValueError("data should be 1D or 2D")
 
     n_samples, n_features = data.shape
-    Nbins = len(bins) - 1
 
     # shuffle all but one axis to get background distribution
     if data_R is None:
@@ -251,9 +250,6 @@ def two_point_angular(ra, dec, bins, method='standard', random_state=None):
         raise ValueError('ra and dec must be 1-dimensional '
                          'arrays of the same length')
 
-    n_features = len(ra)
-    Nbins = len(bins) - 1
-
     # draw a random sample with N points
     ra_R, dec_R = uniform_sphere((min(ra), max(ra)),
                                  (min(dec), max(dec)),
@@ -318,8 +314,6 @@ def bootstrap_two_point_angular(ra, dec, bins, method='standard',
         raise ValueError('ra and dec must be 1-dimensional '
                          'arrays of the same length')
 
-    n_features = len(ra)
-    Nbins = len(bins) - 1
     data = np.asarray(ra_dec_to_xyz(ra, dec), order='F').T
 
     # convert spherical bins to cartesian bins

--- a/astroML/cosmology.py
+++ b/astroML/cosmology.py
@@ -55,7 +55,7 @@ class Cosmology:
         if z == 0:
             return 0
         else:
-            def f(z): 1.0 / self._hinv(z)
+            def f(z): return 1.0 / self._hinv(z)
             integral = integrate.quad(f, 0, z)
             return self.Dh * integral[0]
 

--- a/astroML/cosmology.py
+++ b/astroML/cosmology.py
@@ -55,9 +55,9 @@ class Cosmology:
         if z == 0:
             return 0
         else:
-            f = lambda z: 1.0 / self._hinv(z)
-            I = integrate.quad(f, 0, z)
-            return self.Dh * I[0]
+            def f(z): 1.0 / self._hinv(z)
+            integral = integrate.quad(f, 0, z)
+            return self.Dh * integral[0]
 
     def Dm(self, z):
         """

--- a/astroML/crossmatch.py
+++ b/astroML/crossmatch.py
@@ -87,7 +87,6 @@ def crossmatch_angular(X1, X2, max_distance=np.inf):
     # convert distances back to angles using the law of tangents
     not_inf = ~np.isinf(dist)
     x = 0.5 * dist[not_inf]
-    maximum = np.maximum(0, 1 - x ** 2)
-    dist[not_inf] = (180. / np.pi * 2 * np.arctan2(x, np.sqrt(maximum)))
+    dist[not_inf] = (180. / np.pi * 2 * np.arctan2(x, np.sqrt(np.maximum(0, 1 - x ** 2))))
 
     return dist, ind

--- a/astroML/crossmatch.py
+++ b/astroML/crossmatch.py
@@ -87,7 +87,7 @@ def crossmatch_angular(X1, X2, max_distance=np.inf):
     # convert distances back to angles using the law of tangents
     not_inf = ~np.isinf(dist)
     x = 0.5 * dist[not_inf]
-    dist[not_inf] = (180. / np.pi * 2 * np.arctan2(x,
-                                  np.sqrt(np.maximum(0, 1 - x ** 2))))
+    maximum = np.maximum(0, 1 - x ** 2)
+    dist[not_inf] = (180. / np.pi * 2 * np.arctan2(x, np.sqrt(maximum)))
 
     return dist, ind

--- a/astroML/datasets/rrlyrae_templates.py
+++ b/astroML/datasets/rrlyrae_templates.py
@@ -45,5 +45,4 @@ def fetch_rrlyrae_templates(data_home=None, download_if_missing=True):
     data = tarfile.open(data_file)
 
     return {name.strip('.dat'):
-                  np.loadtxt(data.extractfile(name))
-                 for name in data.getnames()}
+            np.loadtxt(data.extractfile(name)) for name in data.getnames()}

--- a/astroML/datasets/sdss_sspp.py
+++ b/astroML/datasets/sdss_sspp.py
@@ -23,10 +23,10 @@ def compute_distances(data):
     """
     # extinction terms from Berry et al
     Ar = data['Ar']
-    Au = 1.810 * Ar
+    # Au = 1.810 * Ar
     Ag = 1.400 * Ar
     Ai = 0.759 * Ar
-    Az = 0.561 * Ar
+    # Az = 0.561 * Ar
 
     # compute corrected mags and colors
     gmag = data['gpsf'] - Ag

--- a/astroML/datasets/tools/__init__.py
+++ b/astroML/datasets/tools/__init__.py
@@ -4,7 +4,7 @@ tools for the dataset loaders
 
 from .download import download_with_progress_bar
 from .sql_query import sql_query
-from .cas_query import *
+from .cas_query import *  # noqa: F403, F401
 from .sdss_fits import sdss_fits_url, sdss_fits_filename, SDSSfits
 
 

--- a/astroML/datasets/tools/cas_query.py
+++ b/astroML/datasets/tools/cas_query.py
@@ -2,15 +2,16 @@ import numpy as np
 
 from . import sql_query
 
+
 # SDSS primtarget codes
 TARGET_QSO_HIZ            = int('0x00000001', 16)
 TARGET_QSO_CAP	          = int('0x00000002', 16)
-TARGET_QSO_SKIRT	  = int('0x00000004', 16)
+TARGET_QSO_SKIRT	      = int('0x00000004', 16)
 TARGET_QSO_FIRST_CAP	  = int('0x00000008', 16)
 TARGET_QSO_FIRST_SKIRT    = int('0x00000010', 16)
-TARGET_GALAXY_RED	  = int('0x00000020', 16)
+TARGET_GALAXY_RED	      = int('0x00000020', 16)
 TARGET_GALAXY	          = int('0x00000040', 16)
-TARGET_GALAXY_BIG	  = int('0x00000080', 16)
+TARGET_GALAXY_BIG	      = int('0x00000080', 16)
 TARGET_GALAXY_BRIGHT_CORE = int('0x00000100', 16)
 TARGET_ROSAT_A            = int('0x00000200', 16)
 TARGET_ROSAT_B            = int('0x00000400', 16)

--- a/astroML/datasets/tools/cas_query.py
+++ b/astroML/datasets/tools/cas_query.py
@@ -2,16 +2,15 @@ import numpy as np
 
 from . import sql_query
 
-
 # SDSS primtarget codes
 TARGET_QSO_HIZ            = int('0x00000001', 16)
 TARGET_QSO_CAP	          = int('0x00000002', 16)
-TARGET_QSO_SKIRT	      = int('0x00000004', 16)
+TARGET_QSO_SKIRT	  = int('0x00000004', 16)
 TARGET_QSO_FIRST_CAP	  = int('0x00000008', 16)
 TARGET_QSO_FIRST_SKIRT    = int('0x00000010', 16)
-TARGET_GALAXY_RED	      = int('0x00000020', 16)
+TARGET_GALAXY_RED	  = int('0x00000020', 16)
 TARGET_GALAXY	          = int('0x00000040', 16)
-TARGET_GALAXY_BIG	      = int('0x00000080', 16)
+TARGET_GALAXY_BIG	  = int('0x00000080', 16)
 TARGET_GALAXY_BRIGHT_CORE = int('0x00000100', 16)
 TARGET_ROSAT_A            = int('0x00000200', 16)
 TARGET_ROSAT_B            = int('0x00000400', 16)

--- a/astroML/decorators.py
+++ b/astroML/decorators.py
@@ -1,7 +1,7 @@
 import warnings
 
 from astroML.utils.exceptions import AstroMLDeprecationWarning
-from astroML.utils.decorators import pickle_results
+from astroML.utils.decorators import pickle_results  # noqa: F401
 
 
 warnings.warn("'decorators' has been moved to 'astroML.utils' and will be "

--- a/astroML/density_estimation/__init__.py
+++ b/astroML/density_estimation/__init__.py
@@ -1,7 +1,9 @@
 from .density_estimation import KNeighborsDensity
 from .xdeconv import XDGMM
 from .bayesian_blocks import bayesian_blocks
-from .histtools import\
-    scotts_bin_width, freedman_bin_width, knuth_bin_width, histogram
 from .empirical import FunctionDistribution, EmpiricalDistribution
 from .gauss_mixture import GaussianMixture1D
+from .histtools import (scotts_bin_width,
+                        freedman_bin_width,
+                        knuth_bin_width,
+                        histogram)

--- a/astroML/density_estimation/bayesian_blocks.py
+++ b/astroML/density_estimation/bayesian_blocks.py
@@ -338,9 +338,9 @@ def bayesian_blocks(t, x=None, sigma=None,
     best = np.zeros(N, dtype=float)
     last = np.zeros(N, dtype=int)
 
-    #-----------------------------------------------------------------
-    # Start with first data cell; add one cell at each iteration
-    #-----------------------------------------------------------------
+    # -----------------------------------------------------------------
+    #  Start with first data cell; add one cell at each iteration
+    # -----------------------------------------------------------------
     for R in range(N):
         # Compute fit_vec : fitness of putative last block (end at R)
         kwds = {}
@@ -375,9 +375,9 @@ def bayesian_blocks(t, x=None, sigma=None,
         last[R] = i_max
         best[R] = A_R[i_max]
 
-    #-----------------------------------------------------------------
-    # Now find changepoints by iteratively peeling off the last block
-    #-----------------------------------------------------------------
+    # -----------------------------------------------------------------
+    #  Now find changepoints by iteratively peeling off the last block
+    # -----------------------------------------------------------------
     change_points = np.zeros(N, dtype=int)
     i_cp = N
     ind = N

--- a/astroML/density_estimation/density_estimation.py
+++ b/astroML/density_estimation/density_estimation.py
@@ -95,9 +95,6 @@ class KNeighborsDensity(BaseEstimator):
         k = float(self.n_neighbors)
         ndim = X.shape[1]
 
-        # I hope assert is good here given that we only recognize the two methods
-        # and this should have been an error long time ago in all other cases.
-        assert self.method in ["simple", "bayesian"]
         if self.method == 'simple':
             return k / n_volume(dist[:, -1], ndim)
 

--- a/astroML/density_estimation/density_estimation.py
+++ b/astroML/density_estimation/density_estimation.py
@@ -95,6 +95,9 @@ class KNeighborsDensity(BaseEstimator):
         k = float(self.n_neighbors)
         ndim = X.shape[1]
 
+        # I hope assert is good here given that we only recognize the two methods
+        # and this should have been an error long time ago in all other cases.
+        assert self.method in ["simple", "bayesian"]
         if self.method == 'simple':
             return k / n_volume(dist[:, -1], ndim)
 
@@ -104,5 +107,3 @@ class KNeighborsDensity(BaseEstimator):
                     / (dist ** ndim).sum(1))
         else:
             raise ValueError("Unrecognized method '%s'" % self.method)
-
-        return dens

--- a/astroML/density_estimation/xdeconv.py
+++ b/astroML/density_estimation/xdeconv.py
@@ -42,7 +42,7 @@ class XDGMM(BaseEstimator):
     This implementation follows Bovy et al. arXiv 0905.2979
     """
     def __init__(self, n_components, max_iter=100, tol=1E-5, verbose=False,
-                 random_state = None):
+                 random_state=None):
         self.n_components = n_components
         self.max_iter = max_iter
         self.tol = tol
@@ -164,8 +164,8 @@ class XDGMM(BaseEstimator):
 
         T = Xerr + self.V
 
-        #------------------------------------------------------------
-        # compute inverse of each covariance matrix T
+        # ------------------------------------------------------------
+        #  compute inverse of each covariance matrix T
         Tshape = T.shape
         T = T.reshape([n_samples * self.n_components,
                        n_features, n_features])
@@ -173,13 +173,13 @@ class XDGMM(BaseEstimator):
                          for i in range(T.shape[0])]).reshape(Tshape)
         T = T.reshape(Tshape)
 
-        #------------------------------------------------------------
-        # evaluate each mixture at each point
+        # ------------------------------------------------------------
+        #  evaluate each mixture at each point
         N = np.exp(log_multivariate_gaussian(X, self.mu, T, Vinv=Tinv))
 
-        #------------------------------------------------------------
-        # E-step:
-        #  compute q_ij, b_ij, and B_ij
+        # ------------------------------------------------------------
+        #  E-step:
+        #   compute q_ij, b_ij, and B_ij
         q = (N * self.alpha) / np.dot(N, self.alpha)[:, None]
 
         tmp = np.sum(Tinv * w_m[:, :, np.newaxis, :], -1)
@@ -190,9 +190,9 @@ class XDGMM(BaseEstimator):
         B = self.V - np.sum(self.V[:, :, :, np.newaxis]
                             * tmp[:, :, np.newaxis, :, :], -2)
 
-        #------------------------------------------------------------
-        # M-step:
-        #  compute alpha, m, V
+        # ------------------------------------------------------------
+        #  M-step:
+        #   compute alpha, m, V
         qj = q.sum(0)
 
         self.alpha = qj / n_samples
@@ -208,9 +208,13 @@ class XDGMM(BaseEstimator):
     def sample(self, size=1, random_state=None):
         if random_state is None:
             random_state = self.random_state
-        rng = check_random_state(random_state)
+        # I added a noqa here because I don't know if this function is
+        # statefull or not. It looks intentionally placed here given this
+        # functions signature. Remove if unneccessary.
+        rng = check_random_state(random_state)  # noqa: F841
         shape = tuple(np.atleast_1d(size)) + (self.mu.shape[1],)
-        npts = np.prod(size)
+        # Same here, maybe expectation is it will raise an error?
+        npts = np.prod(size)  # noqa: F841
 
         alpha_cs = np.cumsum(self.alpha)
         r = np.atleast_1d(np.random.random(size))

--- a/astroML/density_estimation/xdeconv.py
+++ b/astroML/density_estimation/xdeconv.py
@@ -208,12 +208,8 @@ class XDGMM(BaseEstimator):
     def sample(self, size=1, random_state=None):
         if random_state is None:
             random_state = self.random_state
-        # I added a noqa here because I don't know if this function is
-        # statefull or not. It looks intentionally placed here given this
-        # functions signature. Remove if unneccessary.
         rng = check_random_state(random_state)  # noqa: F841
         shape = tuple(np.atleast_1d(size)) + (self.mu.shape[1],)
-        # Same here, maybe expectation is it will raise an error?
         npts = np.prod(size)  # noqa: F841
 
         alpha_cs = np.cumsum(self.alpha)

--- a/astroML/filters.py
+++ b/astroML/filters.py
@@ -201,8 +201,7 @@ def wiener_filter(t, h, signal='gaussian', noise='flat', return_PSDs=False,
 
     # use [1:] here to remove the zero-frequency term: we don't want to
     # fit to this for data with an offset.
-    def min_func(v): np.sum((PSD[1:] - signal(f[1:], v[0], v[1])
-                             - noise(f[1:], v[2])) ** 2)
+    def min_func(v): return np.sum((PSD[1:] - signal(f[1:], v[0], v[1]) - noise(f[1:], v[2])) ** 2)
     v0 = tuple(signal_params) + tuple(noise_params)
     v = optimize.minimize(min_func, v0, method='Nelder-Mead')['x']
 

--- a/astroML/filters.py
+++ b/astroML/filters.py
@@ -4,6 +4,7 @@ from scipy import optimize, fftpack, signal
 from astroML.utils.decorators import deprecated
 from astroML.utils.exceptions import AstroMLDeprecationWarning
 
+
 # Note: there is a scipy PR to include an improved SG filter within the
 # scipy.signal submodule.  It should replace this when it's finished.
 # see http://github.com/scipy/scipy/pull/304
@@ -200,8 +201,8 @@ def wiener_filter(t, h, signal='gaussian', noise='flat', return_PSDs=False,
 
     # use [1:] here to remove the zero-frequency term: we don't want to
     # fit to this for data with an offset.
-    min_func = lambda v: np.sum((PSD[1:] - signal(f[1:], v[0], v[1])
-                                 - noise(f[1:], v[2])) ** 2)
+    def min_func(v): np.sum((PSD[1:] - signal(f[1:], v[0], v[1])
+                             - noise(f[1:], v[2])) ** 2)
     v0 = tuple(signal_params) + tuple(noise_params)
     v = optimize.minimize(min_func, v0, method='Nelder-Mead')['x']
 

--- a/astroML/linear_model/__init__.py
+++ b/astroML/linear_model/__init__.py
@@ -1,5 +1,3 @@
-import warnings
-
 from .linear_regression import LinearRegression, PolynomialRegression, BasisFunctionRegression
 from .linear_regression_errors import LinearRegressionwithErrors
 

--- a/astroML/linear_model/kernel_regression.py
+++ b/astroML/linear_model/kernel_regression.py
@@ -1,5 +1,4 @@
 import numpy as np
-from .linear_regression import gaussian_basis
 from sklearn.base import BaseEstimator
 from sklearn.metrics import pairwise_kernels
 

--- a/astroML/linear_model/linear_regression.py
+++ b/astroML/linear_model/linear_regression.py
@@ -4,8 +4,8 @@ from sklearn.preprocessing import PolynomialFeatures
 from sklearn.linear_model import LinearRegression, Lasso, Ridge
 
 
-#------------------------------------------------------------
-# Basis functions
+# ------------------------------------------------------------
+#  Basis functions
 def gaussian_basis(X, mu, sigma):
     """Gaussian Basis function
 
@@ -28,7 +28,6 @@ def gaussian_basis(X, mu, sigma):
     sigma = np.atleast_2d(sigma)
 
     n_samples, n_features = X.shape
-    n_bases = mu.shape[0]
 
     if mu.shape[1] != n_features:
         raise ValueError('shape of mu must match shape of X')
@@ -62,9 +61,9 @@ class LinearRegression(BaseEstimator):
     sklearn.linear_model.LinearRegression.
     The difference is that here errors are
     """
-    _regressors = {'none' : LinearRegression,
-                   'l1' : Lasso,
-                   'l2' : Ridge}
+    _regressors = {'none': LinearRegression,
+                   'l1': Lasso,
+                   'l2': Ridge}
 
     def __init__(self, fit_intercept=True, regularization='none', kwds=None):
         if regularization.lower() not in ['l1', 'l2', 'none']:

--- a/astroML/linear_model/linear_regression_errors.py
+++ b/astroML/linear_model/linear_regression_errors.py
@@ -51,8 +51,8 @@ class LinearRegressionwithErrors(LinearRegression):
             eta = pm.Normal('eta', mu=(tt.dot(slope.T, ksi.T) + inter),
                             sigma=int_std, shape=y.shape)
 
-            # observed xi, yi - we don't need xi here though.
-            # x = pm.Normal('xi', mu=ksi.T, sigma=x_error, observed=X, shape=X.shape)
+            # observed xi, yi
+            x = pm.Normal('xi', mu=ksi.T, sigma=x_error, observed=X, shape=X.shape)  # noqa: F841
             y = pm.Normal('yi', mu=eta, sigma=y_error, observed=y, shape=y.shape)
 
             self.trace = pm.sample(**sample_kwargs)

--- a/astroML/linear_model/linear_regression_errors.py
+++ b/astroML/linear_model/linear_regression_errors.py
@@ -51,8 +51,8 @@ class LinearRegressionwithErrors(LinearRegression):
             eta = pm.Normal('eta', mu=(tt.dot(slope.T, ksi.T) + inter),
                             sigma=int_std, shape=y.shape)
 
-            # observed xi, yi
-            x = pm.Normal('xi', mu=ksi.T, sigma=x_error, observed=X, shape=X.shape)
+            # observed xi, yi - we don't need xi here though.
+            # x = pm.Normal('xi', mu=ksi.T, sigma=x_error, observed=X, shape=X.shape)
             y = pm.Normal('yi', mu=eta, sigma=y_error, observed=y, shape=y.shape)
 
             self.trace = pm.sample(**sample_kwargs)

--- a/astroML/linear_model/tests/test_kernel_regression.py
+++ b/astroML/linear_model/tests/test_kernel_regression.py
@@ -44,18 +44,16 @@ def test_X_invalid_shape_exception():
 
     # not valid Xfit.shape[1], should raise an exception
     Xfit = np.array([[4, 5, 6], [1, 2, 3]])
-    y_true = np.ravel(Xfit + 1)
 
     with pytest.raises(Exception) as e:
-        y_fit = clf.predict(Xfit)
+        clf.predict(Xfit)
 
     assert str(e.value) == "dimensions of X do not match training dimension"
 
     # not valid Xfit.shape[1], should raise an exception
     Xfit = np.array([4, 5, 6])
-    y_true = np.ravel(Xfit + 1)
 
     with pytest.raises(Exception) as e:
-        y_fit = clf.predict(Xfit)
+        clf.predict(Xfit)
 
     assert str(e.value) == "X must be two-dimensional"

--- a/astroML/linear_model/tests/test_linear_regression.py
+++ b/astroML/linear_model/tests/test_linear_regression.py
@@ -8,7 +8,7 @@ from astroML.linear_model import \
     LinearRegression, PolynomialRegression, BasisFunctionRegression
 
 try:
-    import pymc3 as pm
+    import pymc3 as pm  # noqa: F401
     HAS_PYMC3 = True
 except ImportError:
     HAS_PYMC3 = False
@@ -76,7 +76,6 @@ def test_LinearRegression_err():
 
     y = np.random.normal(y, dy)
 
-    X_fit = np.linspace(0, 1, 10)[:, None]
     clf1 = LinearRegression().fit(X, y, dy)
     clf2 = skLinearRegression().fit(X / dy, y / dy)
 

--- a/astroML/lumfunc.py
+++ b/astroML/lumfunc.py
@@ -79,7 +79,7 @@ def Cminus(x, y, xmax, ymax):
     # renormalize
     cuml_y *= Nall / cuml_y[-1]
 
-    #now the x direction
+    # now the x direction
     i_sort = np.argsort(x)
     x = x[i_sort]
     y = y[i_sort]

--- a/astroML/plotting/regression.py
+++ b/astroML/plotting/regression.py
@@ -55,7 +55,7 @@ def plot_regressions(ksi, eta, x, y, sigma_x, sigma_y, add_regression_lines=Fals
         dX[:, 0, 0] = sigma_x
         dX[:, 1, 1] = sigma_y
 
-        min_func = lambda beta: -TLS_logL(beta, X, dX)
+        def min_func(beta): -TLS_logL(beta, X, dX)
         beta_fit = optimize.fmin(min_func, x0=[-1, 1])
         m_fit, b_fit = get_m_b(beta_fit)
         x_fit = np.linspace(-10, 10, 20)
@@ -103,7 +103,7 @@ def plot_regression_from_trace(fitted, observed, ax=None, chains=None, multidim_
         print("beta:", slope_best, "alpha:", intercept_best)
         y = intercept_best + slope_best * x
 
-        #y_pre = fitted.predict(x[:, None])
+        # y_pre = fitted.predict(x[:, None])
         ax.plot(x, y, ':', label='fitted')
 
         ax.legend()

--- a/astroML/plotting/regression.py
+++ b/astroML/plotting/regression.py
@@ -55,7 +55,7 @@ def plot_regressions(ksi, eta, x, y, sigma_x, sigma_y, add_regression_lines=Fals
         dX[:, 0, 0] = sigma_x
         dX[:, 1, 1] = sigma_y
 
-        def min_func(beta): -TLS_logL(beta, X, dX)
+        def min_func(beta): return -TLS_logL(beta, X, dX)
         beta_fit = optimize.fmin(min_func, x0=[-1, 1])
         m_fit, b_fit = get_m_b(beta_fit)
         x_fit = np.linspace(-10, 10, 20)

--- a/astroML/plotting/scatter_contour.py
+++ b/astroML/plotting/scatter_contour.py
@@ -105,7 +105,7 @@ def scatter_contour(x, y,
             # this works in newer matplotlib versions
             from matplotlib.path import Path
             points_inside = Path(outer_poly).contains_points(X)
-        except:
+        except ImportError:
             # this works in older matplotlib versions
             import matplotlib.nxutils as nx
             points_inside = nx.points_inside_poly(X, outer_poly)

--- a/astroML/plotting/tests/test_devectorize.py
+++ b/astroML/plotting/tests/test_devectorize.py
@@ -1,13 +1,16 @@
-import matplotlib
-matplotlib.use('Agg')  # don't display plots
+from io import BytesIO
 
 import numpy as np
-from io import BytesIO
 from numpy.testing import assert_
+
+import matplotlib
 from matplotlib import image
 import matplotlib.pyplot as plt
 
 from astroML.plotting.tools import devectorize_axes
+
+
+matplotlib.use('Agg')  # don't display plots
 
 
 def test_devectorize_axes():

--- a/astroML/plotting/tools.py
+++ b/astroML/plotting/tools.py
@@ -129,8 +129,8 @@ def discretize_cmap(cmap, N):
     for key in ('red', 'green', 'blue'):
         # Find the N colors
         D = np.array(cdict[key])
-        I = interpolate.interp1d(D[:, 0], D[:, 1])
-        colors = I(colors_i)
+        interp = interpolate.interp1d(D[:, 0], D[:, 1])
+        colors = interp(colors_i)
         # Place these colors at the correct indices.
         A = np.zeros((N + 1, 3), float)
         A[:, 0] = indices
@@ -138,8 +138,8 @@ def discretize_cmap(cmap, N):
         A[:-1, 2] = colors
         # Create a tuple for the dictionary.
         L = []
-        for l in A:
-            L.append(tuple(l))
+        for c in A:
+            L.append(tuple(c))
         cdict[key] = tuple(L)
     # Return colormap object.
     return LinearSegmentedColormap('colormap', cdict, 1024)

--- a/astroML/plotting/tools.py
+++ b/astroML/plotting/tools.py
@@ -138,8 +138,8 @@ def discretize_cmap(cmap, N):
         A[:-1, 2] = colors
         # Create a tuple for the dictionary.
         L = []
-        for c in A:
-            L.append(tuple(c))
+        for color in A:
+            L.append(tuple(color))
         cdict[key] = tuple(L)
     # Return colormap object.
     return LinearSegmentedColormap('colormap', cdict, 1024)

--- a/astroML/resample.py
+++ b/astroML/resample.py
@@ -42,7 +42,8 @@ def bootstrap(data, n_bootstraps, user_statistic, kwargs=None,
     data = np.asarray(data)
     if data.ndim != 1:
         n_samples = data.shape[0]
-        warnings.warn("bootstrap data are n-dimensional: assuming ordered n_samples by n_attributes")
+        warnings.warn("bootstrap data are n-dimensional: "
+                      "assuming ordered n_samples by n_attributes")
     else:
         n_samples = data.size
 
@@ -57,7 +58,6 @@ def bootstrap(data, n_bootstraps, user_statistic, kwargs=None,
 
     # compute the statistic on the data
     return stat_bootstrap
-
 
 
 def jackknife(data, user_statistic, kwargs=None,

--- a/astroML/stats/__init__.py
+++ b/astroML/stats/__init__.py
@@ -1,7 +1,8 @@
-from ._binned_statistic import (binned_statistic, binned_statistic_2d,
+from ._binned_statistic import (binned_statistic,
+                                binned_statistic_2d,
                                 binned_statistic_dd)
-
-from ._point_statistics import \
-    mean_sigma, sigmaG, median_sigmaG, fit_bivariate_normal
-
+from ._point_statistics import (mean_sigma,
+                                sigmaG,
+                                median_sigmaG,
+                                fit_bivariate_normal)
 from .random import bivariate_normal, trunc_exp, linear

--- a/astroML/stats/_binned_statistic.py
+++ b/astroML/stats/_binned_statistic.py
@@ -294,7 +294,6 @@ def binned_statistic_dd(sample, values, statistic='mean',
     # Using digitize, values that fall on an edge are put in the right bin.
     # For the rightmost bin, we want values equal to the right
     # edge to be counted in the last bin, and not as an outlier.
-    outliers = np.zeros(N, int)
     for i in np.arange(D):
         # Rounding precision
         decimal = int(-np.log10(dedges[i].min())) + 6
@@ -306,7 +305,6 @@ def binned_statistic_dd(sample, values, statistic='mean',
 
     # Compute the sample indices in the flattened statistic matrix.
     ni = nbin.argsort()
-    shape = []
     xy = np.zeros(N, int)
     for i in np.arange(0, D - 1):
         xy += Ncount[ni[i]] * nbin[ni[i + 1:]].prod()
@@ -338,7 +336,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
     elif callable(statistic):
         try:
             null = statistic([])
-        except:
+        except Exception:
             null = np.nan
         result.fill(null)
         for i in np.unique(xy):

--- a/astroML/stats/_point_statistics.py
+++ b/astroML/stats/_point_statistics.py
@@ -1,8 +1,8 @@
 import numpy as np
 from scipy import stats
 
-#from scipy.special import erfinv
-#sigmaG_factor = 1. / (2 * np.sqrt(2) * erfinv(0.5))
+# from scipy.special import erfinv
+# sigmaG_factor = 1. / (2 * np.sqrt(2) * erfinv(0.5))
 sigmaG_factor = 0.74130110925280102
 
 

--- a/astroML/stats/random.py
+++ b/astroML/stats/random.py
@@ -64,8 +64,8 @@ def bivariate_normal(mu=[0, 0], sigma_1=1, sigma_2=1, alpha=0,
         return x
 
 
-#----------------------------------------------------------------------
-# Define some new distributions based on rv_continuous
+# ----------------------------------------------------------------------
+#  Define some new distributions based on rv_continuous
 class trunc_exp_gen(rv_continuous):
     """A truncated positive exponential continuous random variable.
 
@@ -93,6 +93,7 @@ class trunc_exp_gen(rv_continuous):
     def _rvs(self, a, b, k):
         y = np.random.random(self._size)
         return (1. / k) * np.log(1 + y * k / self._const)
+
 
 trunc_exp = trunc_exp_gen(name="trunc_exp", shapes='a, b, k')
 
@@ -129,5 +130,6 @@ class linear_gen(rv_continuous):
         r = np.random.random(self._size)
         return -x0 + np.sqrt(2. * r / c + a * a
                              + 2. * a * x0 + x0 * x0)
+
 
 linear = linear_gen(name="linear", shapes='a, b, c')

--- a/astroML/stats/tests/test_stats.py
+++ b/astroML/stats/tests/test_stats.py
@@ -7,8 +7,8 @@ from astroML.stats import (mean_sigma, median_sigmaG, sigmaG,
 from astroML.stats.random import bivariate_normal, trunc_exp, linear
 
 
-#---------------------------------------------------------------------------
-# Check that mean_sigma() returns the same values as np.mean() and np.std()
+# ---------------------------------------------------------------------------
+#  Check that mean_sigma() returns the same values as np.mean() and np.std()
 @pytest.mark.parametrize("a_shape", [(4, ), (4, 5), (4, 5, 6)])
 @pytest.mark.parametrize("axis", [None, 0])
 @pytest.mark.parametrize("ddof", [0, 1])
@@ -26,10 +26,10 @@ def test_mean_sigma(a_shape, axis, ddof):
     assert_array_almost_equal(sigma1, sigma2)
 
 
-#---------------------------------------------------------------------------
-# Check that the keepdims argument works as expected
-#  we'll later compare median_sigmaG to these results, so that
-#  is effectively tested as well.
+# ---------------------------------------------------------------------------
+#  Check that the keepdims argument works as expected
+#   we'll later compare median_sigmaG to these results, so that
+#   is effectively tested as well.
 @pytest.mark.parametrize("axis", [None, 0, 1, 2])
 def test_mean_sigma_keepdims(axis):
     np.random.seed(0)
@@ -44,9 +44,9 @@ def test_mean_sigma_keepdims(axis):
     assert_array_equal(np.broadcast(a, sigma2).shape, a.shape)
 
 
-#---------------------------------------------------------------------------
-# Check that median_sigmaG matches the values computed using np.percentile
-# and np.median
+# ---------------------------------------------------------------------------
+#  Check that median_sigmaG matches the values computed using np.percentile
+#  and np.median
 @pytest.mark.parametrize("axis", [None, 0, 1, 2])
 def test_median_sigmaG(axis):
     np.random.seed(0)
@@ -79,9 +79,9 @@ def test_sigmaG(axis):
     assert_array_almost_equal(sigmaG1, sigmaG2)
 
 
-#---------------------------------------------------------------------------
-# Check that median_sigmaG() is a good approximation of mean_sigma()
-# for normally-distributed data.
+# ---------------------------------------------------------------------------
+#  Check that median_sigmaG() is a good approximation of mean_sigma()
+#  for normally-distributed data.
 @pytest.mark.parametrize('axis', [None, 1])
 @pytest.mark.parametrize('keepdims', [True, False])
 def test_median_sigmaG_approx(axis, keepdims, atol=0.02):
@@ -95,8 +95,8 @@ def test_median_sigmaG_approx(axis, keepdims, atol=0.02):
     assert_allclose(sigmaG, sigma, atol=atol)
 
 
-#---------------------------------------------------------------------------
-# Check the bivariate normal fit
+# ---------------------------------------------------------------------------
+#  Check the bivariate normal fit
 
 @pytest.mark.parametrize("alpha", np.linspace(-np.pi / 2, np.pi / 2, 7))
 def test_fit_bivariate_normal(alpha):
@@ -124,8 +124,8 @@ def test_fit_bivariate_normal(alpha):
     assert_allclose(sigma2_fit, sigma2, rtol=rtol)
 
 
-#------------------------------------------------------
-# Check truncated exponential and linear functions
+# ------------------------------------------------------
+#  Check truncated exponential and linear functions
 def test_trunc_exp():
     x = np.linspace(0, 10, 100)
     k = 0.25

--- a/astroML/tests/test_correlation.py
+++ b/astroML/tests/test_correlation.py
@@ -4,25 +4,25 @@ from astroML.correlation import uniform_sphere, ra_dec_to_xyz, angular_dist_to_e
 
 
 def test_uniform_sphere():
-	np.random.seed(42)
+    np.random.seed(42)
 
-	# check number of points in 3 axis-aligned cones is approximately the same
-	ra, dec = uniform_sphere((-180,180), (-90,90), 10000)
-	x, y, z = ra_dec_to_xyz(ra, dec)
+    # check number of points in 3 axis-aligned cones is approximately the same
+    ra, dec = uniform_sphere((-180, 180), (-90, 90), 10000)
+    x, y, z = ra_dec_to_xyz(ra, dec)
 
-	assert_allclose(x ** 2 + y ** 2 + z ** 2, np.ones_like(x))
+    assert_allclose(x ** 2 + y ** 2 + z ** 2, np.ones_like(x))
 
-	in_x_cone = (y**2 + z**2 < 0.25).mean()
-	in_y_cone = (x**2 + z**2 < 0.25).mean()
-	in_z_cone = (x**2 + y**2 < 0.25).mean()
+    in_x_cone = (y**2 + z**2 < 0.25).mean()
+    in_y_cone = (x**2 + z**2 < 0.25).mean()
+    in_z_cone = (x**2 + y**2 < 0.25).mean()
 
-	# with prop > 0.999999 should not differ for more than 5 standard deviations
-	assert_allclose(in_x_cone, in_y_cone, atol=5e-2)
-	assert_allclose(in_x_cone, in_z_cone, atol=5e-2)
-	assert_allclose(in_y_cone, in_z_cone, atol=5e-2)
+    # with prop > 0.999999 should not differ for more than 5 standard deviations
+    assert_allclose(in_x_cone, in_y_cone, atol=5e-2)
+    assert_allclose(in_x_cone, in_z_cone, atol=5e-2)
+    assert_allclose(in_y_cone, in_z_cone, atol=5e-2)
 
 
 def test_angular_d_to_euclidean_d():
-	assert_allclose(angular_dist_to_euclidean_dist(180.), 2.)
-	assert_allclose(angular_dist_to_euclidean_dist(60.), 1.)
-	assert_allclose(angular_dist_to_euclidean_dist(0.), 0.)
+    assert_allclose(angular_dist_to_euclidean_dist(180.), 2.)
+    assert_allclose(angular_dist_to_euclidean_dist(60.), 1.)
+    assert_allclose(angular_dist_to_euclidean_dist(0.), 0.)

--- a/astroML/tests/test_fourier.py
+++ b/astroML/tests/test_fourier.py
@@ -1,8 +1,11 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from astroML.fourier import\
-    FT_continuous, IFT_continuous, PSD_continuous, sinegauss, sinegauss_FT
+from astroML.fourier import (FT_continuous,
+                             IFT_continuous,
+                             PSD_continuous,
+                             sinegauss,
+                             sinegauss_FT)
 
 
 @pytest.mark.parametrize('t0', [-1, 0, 1])
@@ -16,15 +19,30 @@ def test_wavelets(t0, f0, Q):
     assert_allclose(H, H2, atol=1E-8)
 
 
-def sinegauss(t, t0, f0, a):
-    """Sine-gaussian wavelet"""
+def sinegauss_a(t, t0, f0, a):
+    """Sine-gaussian wavelet.
+
+    Differs from the ``astroML.fourier.sinegauss`` in that instead of taking a
+    coefficient ``Q`` and calculating the coefficient ``a``, it assumes the
+    given coefficient ``a`` is correct. The relationship between the two is
+    given as:
+
+        a = (f0 * 1. / Q) ** 2
+    """
     return (np.exp(-a * (t - t0) ** 2)
             * np.exp(2j * np.pi * f0 * (t - t0)))
 
 
-def sinegauss_FT(f, t0, f0, a):
+def sinegauss_FT_a(f, t0, f0, a):
     """Fourier transform of the sine-gaussian wavelet.
     This uses the convention H(f) = integral[ h(t) exp(-2pi i f t) dt]
+
+    Differs from the ``astroML.fourier.sinegauss`` in that instead of taking a
+    coefficient ``Q`` and calculating the coefficient ``a``, it assumes the
+    given coefficient ``a`` is correct. The relationship between the two is
+    given as:
+
+        a = (f0 * 1. / Q) ** 2
     """
     return (np.sqrt(np.pi / a)
             * np.exp(-2j * np.pi * f * t0)
@@ -46,9 +64,9 @@ def sinegauss_PSD(f, t0, f0, a):
 @pytest.mark.parametrize('method', [1, 2])
 def test_FT_continuous(a, t0, f0, method):
     t = np.linspace(-9, 10, 10000)
-    h = sinegauss(t, t0, f0, a)
+    h = sinegauss_a(t, t0, f0, a)
     f, H = FT_continuous(t, h, method=method)
-    assert_allclose(H, sinegauss_FT(f, t0, f0, a), atol=1E-12)
+    assert_allclose(H, sinegauss_FT_a(f, t0, f0, a), atol=1E-12)
 
 
 @pytest.mark.parametrize('a', [1, 2])
@@ -57,7 +75,7 @@ def test_FT_continuous(a, t0, f0, method):
 @pytest.mark.parametrize('method', [1, 2])
 def test_PSD_continuous(a, t0, f0, method):
     t = np.linspace(-9, 10, 10000)
-    h = sinegauss(t, t0, f0, a)
+    h = sinegauss_a(t, t0, f0, a)
     f, P = PSD_continuous(t, h, method=method)
     assert_allclose(P, sinegauss_PSD(f, t0, f0, a), atol=1E-12)
 
@@ -68,9 +86,9 @@ def test_PSD_continuous(a, t0, f0, method):
 @pytest.mark.parametrize('method', [1, 2])
 def check_IFT_continuous(a, t0, f0, method):
     f = np.linspace(-9, 10, 10000)
-    H = sinegauss_FT(f, t0, f0, a)
+    H = sinegauss_FT_a(f, t0, f0, a)
     t, h = IFT_continuous(f, H, method=method)
-    assert_allclose(h, sinegauss(t, t0, f0, a), atol=1E-12)
+    assert_allclose(h, sinegauss_a(t, t0, f0, a), atol=1E-12)
 
 
 def test_IFT_FT():

--- a/astroML/tests/test_resample.py
+++ b/astroML/tests/test_resample.py
@@ -54,10 +54,11 @@ def test_bootstrap_multiple():
     assert_allclose(res[0], dist_mean)
     assert_allclose(res[1], dist_std)
 
+
 def test_bootstrap_covar():
     np.random.seed(0)
-    mean = [0.,0.]
-    covar = [[10.,3.],[3.,20.]]
+    mean = [0., 0.]
+    covar = [[10., 3.], [3., 20.]]
     x = np.random.multivariate_normal(mean, covar, 1000)
 
     dist_cov = bootstrap(x, 10000, np.cov, kwargs=dict(rowvar=0), random_state=0)

--- a/astroML/time_series/__init__.py
+++ b/astroML/time_series/__init__.py
@@ -1,5 +1,9 @@
 from .ACF import ACF_scargle, ACF_EK
-from .periodogram import lomb_scargle, lomb_scargle_bootstrap, \
-    lomb_scargle_AIC, lomb_scargle_BIC, multiterm_periodogram, \
-    search_frequencies, MultiTermFit
 from .generate import generate_power_law, generate_damped_RW
+from .periodogram import (lomb_scargle,
+                          lomb_scargle_bootstrap,
+                          lomb_scargle_AIC,
+                          lomb_scargle_BIC,
+                          multiterm_periodogram,
+                          search_frequencies,
+                          MultiTermFit)

--- a/astroML/time_series/generate.py
+++ b/astroML/time_series/generate.py
@@ -34,7 +34,7 @@ def generate_power_law(N, dt, beta, generate_complex=False, random_state=None):
     N = int(N)
 
     Npos = int(N / 2)
-    Nneg = int((N - 1) / 2)
+    # Nneg = int((N - 1) / 2)
     domega = (2 * np.pi / dt / N)
 
     if generate_complex:

--- a/astroML/time_series/periodogram.py
+++ b/astroML/time_series/periodogram.py
@@ -156,8 +156,7 @@ def lomb_scargle_AIC(P, y, dy, n_harmonics=1):
     P, y, dy = map(np.asarray(P, y, dy))
     w = 1. / dy ** 2
     mu = np.dot(w, y) / w.sum()
-    N = len(y)
-    return np.sum(((y_obs - mu) / dy) ** 2) * P - (2 * n_harmonics + 1) * 2
+    return np.sum(((y - mu) / dy) ** 2) * P - (2 * n_harmonics + 1) * 2
 
 
 def lomb_scargle_BIC(P, y, dy, n_harmonics=1):

--- a/astroML/utils/decorators.py
+++ b/astroML/utils/decorators.py
@@ -12,7 +12,9 @@ from astroML.utils.exceptions import AstroMLDeprecationWarning
 # added in v2.0.10 LTS and v3.1
 av = astropy.__version__
 ASTROPY_LT_31 = (LooseVersion(av) < LooseVersion("2.0.10") or
-                 (LooseVersion("3.0") <= LooseVersion(av) and LooseVersion(av) < LooseVersion("3.1")))
+                 (LooseVersion("3.0") <= LooseVersion(av) and
+                  LooseVersion(av) < LooseVersion("3.1")))
+
 
 __all__ = ['pickle_results', 'deprecated']
 
@@ -59,7 +61,7 @@ def pickle_results(filename=None, verbose=True):
             try:
                 D = pickle.load(open(filename, 'rb'))
                 cache_exists = True
-            except:
+            except Exception:
                 D = {}
                 cache_exists = False
 
@@ -67,15 +69,17 @@ def pickle_results(filename=None, verbose=True):
             Dargs = D.get('args')
             Dkwargs = D.get('kwargs')
 
+            # TODO: figure out what errors are raised here.
             try:
                 args_match = (args == Dargs)
-            except:
+            except:  # noqa: E722
                 args_match = np.all([np.all(a1 == a2)
                                      for (a1, a2) in zip(Dargs, args)])
 
+            # TODO: figure out what errors are raised here.
             try:
                 kwargs_match = (kwargs == Dkwargs)
-            except:
+            except:  # noqa: E722
                 kwargs_match = ((sorted(Dkwargs.keys())
                                  == sorted(kwargs.keys()))
                                 and (np.all([np.all(Dkwargs[key]

--- a/astroML/utils/decorators.py
+++ b/astroML/utils/decorators.py
@@ -58,14 +58,15 @@ def pickle_results(filename=None, verbose=True):
             filename = '%s_output.pkl' % f.__name__
 
         def new_f(*args, **kwargs):
+            # While loading, pickle, can raise any number of errors. Cover cases
+            # when FileNotFoundError or when when pickle raises an error as equivalent.
+            # In either case the data in the cache will have to be regenerated.
             try:
-                pickledFile = open(filename, 'rb')
-            except FileNotFoundError:
+                D = pickle.load(open(filename, 'rb'))
+                cache_exists = True
+            except Exception:
                 D = {}
                 cache_exists = False
-            else:
-                D = pickle.load(pickledFile)
-                cache_exists = True
 
             # simple comparison doesn't work in the case of numpy arrays
             Dargs = D.get('args')

--- a/astroML/utils/decorators.py
+++ b/astroML/utils/decorators.py
@@ -59,27 +59,27 @@ def pickle_results(filename=None, verbose=True):
 
         def new_f(*args, **kwargs):
             try:
-                D = pickle.load(open(filename, 'rb'))
-                cache_exists = True
-            except Exception:
+                pickledFile = open(filename, 'rb')
+            except FileNotFoundError:
                 D = {}
                 cache_exists = False
+            else:
+                D = pickle.load(pickledFile)
+                cache_exists = True
 
             # simple comparison doesn't work in the case of numpy arrays
             Dargs = D.get('args')
             Dkwargs = D.get('kwargs')
 
-            # TODO: figure out what errors are raised here.
             try:
                 args_match = (args == Dargs)
-            except:  # noqa: E722
+            except ValueError:
                 args_match = np.all([np.all(a1 == a2)
                                      for (a1, a2) in zip(Dargs, args)])
 
-            # TODO: figure out what errors are raised here.
             try:
                 kwargs_match = (kwargs == Dkwargs)
-            except:  # noqa: E722
+            except ValueError:
                 kwargs_match = ((sorted(Dkwargs.keys())
                                  == sorted(kwargs.keys()))
                                 and (np.all([np.all(Dkwargs[key]

--- a/astroML/utils/tests/test_utils.py
+++ b/astroML/utils/tests/test_utils.py
@@ -1,7 +1,10 @@
 import numpy as np
 
 from numpy.testing import assert_array_almost_equal, assert_allclose
-from astroML.utils import log_multivariate_gaussian, convert_2D_cov, completeness_contamination, split_samples
+from astroML.utils import (log_multivariate_gaussian,
+                           convert_2D_cov,
+                           completeness_contamination,
+                           split_samples)
 
 
 def positive_definite_matrix(N, M=None):
@@ -73,23 +76,22 @@ def test_2D_cov():
 
 
 def test_completeness_contamination():
-    completeness, contamination = \
-                    completeness_contamination(np.ones(100), np.ones(100))
+    completeness, contamination = completeness_contamination(np.ones(100),
+                                                             np.ones(100))
 
     assert_allclose(completeness, 1)
     assert_allclose(contamination, 0)
 
-    completeness, contamination = \
-                    completeness_contamination(np.zeros(100), np.zeros(100))
+    completeness, contamination = completeness_contamination(np.zeros(100),
+                                                             np.zeros(100))
 
     assert_allclose(completeness, 0)
     assert_allclose(contamination, 0)
 
-    completeness, contamination = \
-                completeness_contamination(
-                    np.concatenate((np.ones(50), np.zeros(50))),
-                    np.concatenate((np.ones(25), np.zeros(50), np.ones(25)))
-                )
+    completeness, contamination = completeness_contamination(
+        np.concatenate((np.ones(50), np.zeros(50))),
+        np.concatenate((np.ones(25), np.zeros(50), np.ones(25)))
+    )
 
     assert_allclose(completeness, 0.5)
     assert_allclose(contamination, 0.5)

--- a/astroML/utils/utils.py
+++ b/astroML/utils/utils.py
@@ -182,7 +182,6 @@ def completeness_contamination(predicted, true):
     matches = (predicted == true)
 
     tp = np.sum(matches & (true != 0), -1)
-    # tn = np.sum(matches & (true == 0), -1)
     fp = np.sum(~matches & (true == 0), -1)
     fn = np.sum(~matches & (true != 0), -1)
 

--- a/astroML/utils/utils.py
+++ b/astroML/utils/utils.py
@@ -182,7 +182,7 @@ def completeness_contamination(predicted, true):
     matches = (predicted == true)
 
     tp = np.sum(matches & (true != 0), -1)
-    tn = np.sum(matches & (true == 0), -1)
+    # tn = np.sum(matches & (true == 0), -1)
     fp = np.sum(~matches & (true == 0), -1)
     fn = np.sum(~matches & (true != 0), -1)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,6 @@ filterwarnings =
 
 [flake8]
 max-line-length = 100
+per-file-ignores =
+    astroML/datasets/tools/cas_query.py:E223, E221
+exclude = __init__.py


### PR DESCRIPTION
I noticed the majority of the flake8 warnings were purely due to the imports in various dunder init files. Excluding them brought the number of flake8 errors down significantly so I decided to just flakeify the entire thing. 

It was a rather forced job though, so a fresh pair of eyes is very welcomed. I wouldn't want the end code to be worse off than the initial one. 

Couple of remarks however: 

* I did notice many of the `init.py` files were quite messy so I did go through them and used parenthesized one-lined import statements wherever more than 3 imports were present in a line. I don't know if this is a liked style, I just like the prospects of maintainability because it's easy to notice what changes going forward.
* Assigned but unused errors have been dealt with by removing the entries, except in cases where the removed entry was more than just a trivial expression (f.e. `N=len(n)`, see `sdss_sspp.py` for opposite example). In those cases the expressions were converted to comments. These should be safe to remove, I just didn't dare to. 
* `cas_query.py` was exempt from `flake8` operator and spaces errors due to the large list of flags in it. 
* In tests where function invocation is required for error capturing I have removed assigning of the result. This can be brought back with a `noqa` flag if it's against astroML style for debugging.
* `density_estimation.py` had a bug where an extra `return` existed at the end, but was returning an undeclared value. It was never hit because it should have been impossible for it to be hit. I added an `assert` statement ensuring one of the returns in `if-else` block will be hit and removed the extra return. Perhaps `self.method` should become a property without a setter?
* `xdeconv.py` lines 211 onward invoke an unfamiliar `sklearn` functionality which I wasn't sure was or wasn't state-full. The returned values are unused but they seem to be performing some kind of a check on the given method parameters. I think it's safe to remove them, but I don't know. It looks strange. I have given them a `noqa` flag.
* Some code, like the one in `_binned_statistic.py`, uses a `try-except` block without a specified exception. In those cases I have attempted to catch the correct error whenever I could. In some situations I couldn't, or was too lazy to, resolve all of the potential error types. These locations are marked with a comment starting with `TODO` so they should be easy to find later on. In case of `_binned_statistic.py` catching a broad spectrum of exceptions actually makes sense, but in several other locations it really doesn't - I was just lazy to entangle what are all the possible exceptions. Someone might want to take a peek at these.
* `test_fourier.py` is very messy because it imports a function from `fourrier.py`, uses it, then redefines it by a local function using the same name. I have attempted to fix that, but someone that understands the tests better might want to take a look at them. 


`flake8 astroML` should pass without an error. 