### PR TITLE
Point the README's license badge to the license of the project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ AstroML: Machine Learning for Astronomy
 .. image:: https://img.shields.io/pypi/dm/astroML.svg?style=flat
         :target: https://pypi.python.org/pypi/astroML
 .. image:: https://img.shields.io/badge/license-BSD-blue.svg?style=flat
-        :target: https://github.com/astroml/astroml/blob/master/LICENSE
+        :target: https://github.com/astroml/astroml/blob/main/LICENSE.rst
 
 AstroML is a Python module for machine learning and data mining
 built on numpy, scipy, scikit-learn, and matplotlib,


### PR DESCRIPTION
Hi, 

Thanks for open-sourcing this, it's a great resource. I particularly like the broadcast visualisations (http://www.astroml.org/book_figures/appendix/fig_broadcast_visual.html) and so came to check the license of the project.  I noticed that the license badge was broken, so I thought that I would put in a very quick PR to fix it whilst I was passing through, feel free to ignore!

Thanks,
Michael Radigan