### PR TITLE
Adding fetch_sdss_galaxy_images

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 1.0.2 (unreleased)
 ==================
 
+- Add ``fetch_sdss_galaxy_images`` to download sample of SDSS galaxy images
+  for CNN figure example. [#242]
 - Fix bug in ``lumfunc.Cminus`` that lead to return NaN values. [#237]
 
 

--- a/astroML/datasets/__init__.py
+++ b/astroML/datasets/__init__.py
@@ -23,3 +23,4 @@ from .hogg2010test import fetch_hogg2010test
 from .rrlyrae_templates import fetch_rrlyrae_templates
 from .sdss_filters import fetch_sdss_filter, fetch_vega_spectrum
 from .kelly2007test import simulation_kelly
+from .sdss_galaxy_images import fetch_sdss_galaxy_images

--- a/astroML/datasets/sdss_galaxy_images.py
+++ b/astroML/datasets/sdss_galaxy_images.py
@@ -17,7 +17,7 @@ def fetch_sdss_galaxy_images(data_home=None, download_if_missing=True):
     """
     Loader for SDSS galaxy images.
 
-    A sample of coloured 1000 galaxy image stamps are loaded along with
+    A sample of 1000 coloured galaxy image stamps are loaded along with
     labels for their morphological classification.
 
     Parameters
@@ -40,7 +40,8 @@ def fetch_sdss_galaxy_images(data_home=None, download_if_missing=True):
 
     Notes
     -----
-    Data is from Nair & Abraham 2010 ApJS 186:427
+    The sample selection is courtesy of Marc Huertas-Company from the
+    full dataset of Nair & Abraham 2010 ApJS 186:427.
     """
 
     data_home = get_data_home(data_home)

--- a/astroML/datasets/sdss_galaxy_images.py
+++ b/astroML/datasets/sdss_galaxy_images.py
@@ -1,0 +1,67 @@
+import os
+from io import BytesIO
+from gzip import GzipFile
+
+import numpy as np
+
+from astroML.datasets import get_data_home
+from astroML.datasets.tools import download_with_progress_bar
+
+IMAGES_URL = ('https://github.com/astroML/astroML-data/raw/main/datasets/'
+              'sdss_images_1000.npy.gz')
+LABELS_URL = ('https://github.com/astroML/astroML-data/raw/main/datasets/'
+              'sdss_labels_1000.npy')
+
+
+def fetch_sdss_galaxy_images(data_home=None, download_if_missing=True):
+    """
+    Loader for SDSS galaxy images.
+
+    A sample of coloured 1000 galaxy image stamps are loaded along with
+    labels for their morphological classification.
+
+    Parameters
+    ----------
+    data_home : optional, default=None
+        Specify another download and cache folder for the datasets. By default
+        all astroML data is stored in '~/astroML_data'.
+
+    download_if_missing : optional, default=True
+        If False, raise a IOError if the data is not locally available
+        instead of trying to download the data from the source site.
+
+    Returns
+    -------
+    data : ndarray, shape = (1000, 68, 68, 3)
+        Array containing image data for 1000 galaxies in 3 colours.
+
+    labels: ndarray, shape = (1000,)
+        Labels of morphological classification (1 for spiral, 0 for elliptical).
+
+    Notes
+    -----
+    Data is from Nair & Abraham 2010 ApJS 186:427
+    """
+
+    data_home = get_data_home(data_home)
+
+    images_file = os.path.join(data_home, os.path.basename(IMAGES_URL).split('.gz')[0])
+    labels_file = os.path.join(data_home, os.path.basename(LABELS_URL))
+
+    if not os.path.exists(images_file) or not os.path.exists(labels_file):
+        if not download_if_missing:
+            raise IOError('data not present on disk. '
+                          'set download_if_missing=True to download')
+
+        zipped_buf = download_with_progress_bar(IMAGES_URL, return_buffer=True)
+        gzf = GzipFile(fileobj=zipped_buf, mode='rb')
+        data = np.load(BytesIO(gzf.read()))
+        np.save(images_file, data)
+        labels_buffer = download_with_progress_bar(LABELS_URL, return_buffer=True)
+        labels = np.load(labels_buffer)
+        np.save(labels_file, labels)
+    else:
+        data = np.load(images_file)
+        labels = np.load(labels_file)
+
+    return data, labels


### PR DESCRIPTION
To download  `sdss_images_1000.npy` needed for the CNN figure: http://www.astroml.org/book_figures/chapter9/fig_morph_nn.html

(figure also needs updating to use this function, it will be in a separate PR for the other repo).

@connolly - could you please double check that I did get the source of the data right?

