### PR TITLE
addresses issue #257: get version number from package metadata in __i…

### DIFF
--- a/astroML/__init__.py
+++ b/astroML/__init__.py
@@ -1,4 +1,6 @@
-__version__ = '1.0.2'
+from pkg_resources import get_distribution
+
+__version__ = get_distribution('astroML').version
 
 __citation__ = """@INPROCEEDINGS{astroML,
  author={{Vanderplas}, J.T. and {Connolly}, A.J.


### PR DESCRIPTION
…nit__.py

Let me know if there are any modifications I should make!

### **Solution:**

```py
from pkg_resources import get_distribution

__version__ = get_distribution('astroML').version
```

As one of the solutions from https://packaging.python.org/en/latest/guides/single-sourcing-package-version/. 

### **Fixed Behavior:**
previously (using a virtual env that the cloned repo is installed into):
`pipenv run python -c "import astroML; print(astroML.__version__)" -> 1.0.2`
now:
`pipenv run python -c "import astroML; print(astroML.__version__)" -> 1.0.3.dev0`

Which now (mostly) matches the behavior from
`pipenv run python setup.py --version -> 1.0.3.dev` _(missing the zero)_


### **Alternative Modifications / Alternative Solutions:**
Add a try/except for errors when astroML isn't installed yet or if version number is undefined (what setuptools does):
https://github.com/pypa/setuptools/blob/main/setuptools/version.py#L1

```py
import pkg_resources

try:
    __version__ = pkg_resources.get_distribution('setuptools').version
except Exception:
    __version__ = 'unknown'
```

**Alt Solution 1: importlib_metadata**
Apparently pkg_resources is being deprecated in favor of importlib_metadata, but importlib_metadata is only a built-in for python >=3.8, otherwise you need to add the backport as an install requires for setup.py/cfg. It seems like astroML is definitely supporting python<3.8, so I went for the solution that didn't add an extra dependency. Perhaps in the future when the support for python is only >=3.8, could use importlib_metadata?

**Alt Solution 2: setuptools_scm**
Switch to setuptools_scm to grab the version from the git tag. More complicated, but the version number wouldn't need to be hardcoded anywhere except the git tags(?). Wouldn't need to update the setup.cfg with a ".dev" in the version either; it should auto-generate the .dev after any commits that aren't tagged. I think this would ensure that the number generated after .dev would be the same across all methods of checking the version number.

This would mean adding setuptools_scm to setup_requires for setup.py (setup.py & setup.cfg usage are both deprecated in favor of pyproject.toml).
Nice, quick overview: https://www.moritzkoerber.com/posts/versioning-with-setuptools_scm/ & https://github.com/pypa/setuptools_scm