### PR TITLE
MAINT: Update deprecated usage of scipy arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ book_figures/*/*.pkl
 
 .coverage
 .pytest_cache
+.tox
+.hypothesis

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,15 @@
+1.0.3 (unreleased)
+==================
+
+- Minimum required scipy version is now 0.19. [#266]
+
+
 1.0.2 (2022-01-25)
 ==================
 
 - Add ``fetch_sdss_galaxy_images`` to download sample of SDSS galaxy images
   for CNN figure example. [#242]
 - Fix bug in ``lumfunc.Cminus`` that lead to return NaN values. [#237]
-
 
 1.0.1 (2020-09-09)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ functionality might work with older versions):
 
 - Python_ version 3.6+
 - Numpy_ >= 1.13
-- Scipy_ >= 0.18
+- Scipy_ >= 0.19
 - Scikit-learn_ >= 0.18
 - Matplotlib_ >= 3.0
 - AstroPy_ >= 3.0

--- a/astroML/dimensionality/iterative_pca.py
+++ b/astroML/dimensionality/iterative_pca.py
@@ -124,7 +124,7 @@ def iterative_pca(X, M, n_ev=5, n_iter=15, norm=None, full_output=False):
         VWx = np.dot(VT[:n_ev], (notM * X_centered).T)
         for i in range(n_samples):
             VWV = np.dot(VT[:n_ev], (notM[i] * VT[:n_ev]).T)
-            coeffs[i] = solve(VWV, VWx[:, i], sym_pos=True, overwrite_a=True)
+            coeffs[i] = solve(VWV, VWx[:, i], assume_a="pos", overwrite_a=True)
 
         X_fill = mu + np.dot(coeffs, VT[:n_ev])
         X_recons[M] = X_fill[M]

--- a/doc/user_guide/installation.rst
+++ b/doc/user_guide/installation.rst
@@ -88,7 +88,7 @@ The core ``astroML`` package requires the following:
 
 - `Python <http://python.org>`_ version 3.6+
 - `Numpy <http://numpy.scipy.org/>`_ >= 1.13
-- `Scipy <http://www.scipy.org/>`_ >= 0.18
+- `Scipy <http://www.scipy.org/>`_ >= 0.19
 - `scikit-learn <http://scikit-learn.org/>`_ >= 0.18
 - `matplotlib <http://matplotlib.org/>`_ >= 3.0
 - `astropy <http://www.astropy.org/>`_ >= 3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ exclude = __init__.py
 install_requires =
     scikit-learn>=0.18
     numpy>=1.13
-    scipy>=0.18
+    scipy>=0.19
     matplotlib>=3.0
     astropy>=3.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     oldestdeps: matplotlib==3.0.3
     oldestdeps: numpy==1.13.3
     oldestdeps: scikit-learn==0.18.2
-    oldestdeps: scipy==0.18.1
+    oldestdeps: scipy==0.19.0
     oldestdeps: astropy<=3.2
     oldestdeps: pymc3==3.7   # optional dependency, but we include it here
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps =
     oldestdeps: numpy==1.13.3
     oldestdeps: scikit-learn==0.18.2
     oldestdeps: scipy==0.19.0
-    oldestdeps: astropy<=3.2
+    oldestdeps: astropy==3.0
     oldestdeps: pymc3==3.7   # optional dependency, but we include it here
 
     alldeps: arviz<0.11      # FIXME: temporary limitation as pymc 3.10 is not compatible with newer arviz


### PR DESCRIPTION
Technically we can wait a little bit more, but I would err on the side of fixing this sooner rather than later.  This fixes #265 


```
Deprecated since version 0.19.0: This keyword is deprecated and should be replaced by using assume_a = 'pos'. sym_pos will be removed in SciPy 1.11.0.
```

We likely need to bump the minimum required version of scipy to 0.19, will do it once this need is confirmed by CI. 0.19 has been first released in Mar 2017, so I don't see any controversy in bumping the requirement. 