### PR TITLE
CI: fix latex install for failing docs build

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -89,6 +89,7 @@ jobs:
         # of tex-extras. Testing shows that docs will *not* compile without
         # explicitly installing all 3 though.
         run: |
+          sudo apt update
           sudo apt install -y texlive-latex-recommended
           sudo apt install -y texlive-latex-extra
           sudo apt install -y cm-super

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
 addopts = --doctest-plus
 doctest_plus = enabled
 doctest_rst = True
-testspaths = astroML doc examples
+testpaths = astroML doc examples
 doctest_optionflags = FLOAT_CMP ELLIPSIS NORMALIZE_WHITESPACE
 filterwarnings =
     error::DeprecationWarning


### PR DESCRIPTION
The docs build started to fail in the latest cron job, I expect this should fix the latex install. 

The PR also includes another minor config typo